### PR TITLE
2015 12 bontric fix integer handling

### DIFF
--- a/src/rpc/db/function.c
+++ b/src/rpc/db/function.c
@@ -281,11 +281,10 @@ static int db_function_typecheck(string apikey, string name,
         return (-1);
       }
 
-      if(val == OBJECT_TYPE_INT){
+      if(val == OBJECT_TYPE_INT && args->obj[k].type == OBJECT_TYPE_UINT){
         /* Any positive integer will be treated as and unsigned int
          * (see unpack/pack.c) and might be a valid signed integer */
-        if(args->obj[k].type == OBJECT_TYPE_UINT &&
-           args->obj[k].data.uinteger > INT64_MAX){
+        if(args->obj[k].data.uinteger > INT64_MAX){
           LOG_WARNING("run() function argument has wrong type.");
           freeReplyObject(reply);
           return (-1);

--- a/src/rpc/db/function.c
+++ b/src/rpc/db/function.c
@@ -281,7 +281,12 @@ static int db_function_typecheck(string apikey, string name,
         return (-1);
       }
 
-      if (val != args->obj[k].type) {
+      if (val != args->obj[k].type &&
+          /* Any positive integer will be treated as and unsigned int
+           * (see unpack/pack.c)  and is therefore a valid signed integer */
+          !(val == OBJECT_TYPE_INT && args->obj[k].type != OBJECT_TYPE_INT &&
+            args->obj[k].type != OBJECT_TYPE_UINT)) {
+
         LOG_WARNING("run() function argument has wrong type.");
         freeReplyObject(reply);
         return (-1);

--- a/src/rpc/db/function.c
+++ b/src/rpc/db/function.c
@@ -281,12 +281,16 @@ static int db_function_typecheck(string apikey, string name,
         return (-1);
       }
 
-      if (val != args->obj[k].type &&
-          /* Any positive integer will be treated as and unsigned int
-           * (see unpack/pack.c)  and is therefore a valid signed integer */
-          !(val == OBJECT_TYPE_INT && args->obj[k].type != OBJECT_TYPE_INT &&
-            args->obj[k].type != OBJECT_TYPE_UINT)) {
-
+      if(val == OBJECT_TYPE_INT){
+        /* Any positive integer will be treated as and unsigned int
+         * (see unpack/pack.c) and might be a valid signed integer */
+        if(args->obj[k].type == OBJECT_TYPE_UINT &&
+           args->obj[k].data.uinteger > INT64_MAX){
+          LOG_WARNING("run() function argument has wrong type.");
+          freeReplyObject(reply);
+          return (-1);
+        }
+      } else if (val != args->obj[k].type){
         LOG_WARNING("run() function argument has wrong type.");
         freeReplyObject(reply);
         return (-1);

--- a/src/rpc/msgpack/pack.c
+++ b/src/rpc/msgpack/pack.c
@@ -177,10 +177,10 @@ int pack_params(msgpack_packer *pk, struct message_params_object params)
 
     switch (type) {
     case (OBJECT_TYPE_INT):
-      pack_uint64(pk, object->data.uinteger);
+      pack_int64(pk, object->data.integer);
       continue;
     case (OBJECT_TYPE_UINT):
-      pack_int64(pk, object->data.integer);
+      pack_uint64(pk, object->data.uinteger);
       continue;
     case (OBJECT_TYPE_BOOL):
       pack_bool(pk, object->data.boolean);

--- a/src/rpc/msgpack/unpack.c
+++ b/src/rpc/msgpack/unpack.c
@@ -98,11 +98,11 @@ int unpack_params(msgpack_object *obj, struct message_params_object *params)
 
     switch (tmp->type) {
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
-      elem->type = OBJECT_TYPE_INT;
+      elem->type = OBJECT_TYPE_UINT;
       elem->data.uinteger = unpack_uint(tmp);
       continue;
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
-      elem->type = OBJECT_TYPE_UINT;
+      elem->type = OBJECT_TYPE_INT;
       elem->data.integer = unpack_int(tmp);
       continue;
     case MSGPACK_OBJECT_STR:


### PR DESCRIPTION
Errors in un-/pack.c are self-explanatory.

Since any positive integer is treated as an unsigned integer and any negative integer as signed, a positive integer (and therefore an unsigned integer) might also be a valid signed integer. 
To make the type check work, the value has to be checked as well to verify that it's a signed integer.
