### PR TITLE
Message forwarding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,9 @@ set(SPLONEBOX-SOURCES
   src/queue.h
   src/string.c
   src/reallocarray.c
-  src/hashmap.c
+  src/hashmap-string.c
+  src/hashmap-uint64.c
+  src/random.c
   src/optparser.c
   src/api/sb-api.h
   src/api/apikey.c
@@ -146,7 +148,8 @@ set(TEST-SOURCES
   src/queue.h
   src/string.c
   src/reallocarray.c
-  src/hashmap.c
+  src/hashmap-string.c
+  src/hashmap-uint64.c
   src/optparser.c
   src/api/sb-api.h
   src/api/apikey.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ set(TEST-SOURCES
   src/reallocarray.c
   src/hashmap-string.c
   src/hashmap-uint64.c
+  src/random.c
   src/optparser.c
   src/api/sb-api.h
   src/api/apikey.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SPLONEBOX-SOURCES
   src/main.c
   src/sb-common.h
   src/khash.h
+  src/kvec.h
   src/queue.h
   src/string.c
   src/reallocarray.c

--- a/src/api/register.c
+++ b/src/api/register.c
@@ -62,19 +62,17 @@ int api_register(string api_key, string name, string desc, string author,
   return (0);
 }
 
-int api_register_response(uint32_t msgid, msgpack_packer *pk)
+struct message_params_object * api_register_response(
+    struct api_error *api_error)
 {
-  struct message_response *response;
+  struct message_params_object *params;
 
-  response = CALLOC(1, struct message_response);
+  params = CALLOC(1, struct message_params_object);
 
-  if (!response)
-    return (-1);
+  if (!api_error || !params)
+    return (NULL);
 
-  response->msgid = msgid;
-  response->params.size = 0;
+  params->size = 0;
 
-  message_serialize_response(response, pk);
-
-  return (0);
+  return params;
 }

--- a/src/api/register.c
+++ b/src/api/register.c
@@ -61,3 +61,20 @@ int api_register(string api_key, string name, string desc, string author,
 
   return (0);
 }
+
+int api_register_response(uint32_t msgid, msgpack_packer *pk)
+{
+  struct message_response *response;
+
+  response = CALLOC(1, struct message_response);
+
+  if (!response)
+    return (-1);
+
+  response->msgid = msgid;
+  response->params.size = 0;
+
+  message_serialize_response(response, pk);
+
+  return (0);
+}

--- a/src/api/run.c
+++ b/src/api/run.c
@@ -85,3 +85,28 @@ struct message_params_object * api_run(string pluginlongtermpk,
 
   return (run_params);
 }
+
+struct message_params_object * api_run_response(string pluginlongtermpk,
+    uint64_t callid, struct api_error *api_error)
+{
+  struct message_params_object *params;
+
+  params = CALLOC(1, struct message_params_object);
+
+  if (!api_error || !params)
+    return (NULL);
+
+  /* check if id is in database */
+  if (db_apikey_verify(pluginlongtermpk) == -1) {
+    error_set(api_error, API_ERROR_TYPE_VALIDATION, "API key is invalid.");
+    return (NULL);
+  }
+
+  params->size = 1;
+  params->obj = CALLOC(1, struct message_object);
+
+  params->obj[0].type = OBJECT_TYPE_UINT;
+  params->obj[0].data.uinteger = callid;
+
+  return (params);
+}

--- a/src/api/sb-api.h
+++ b/src/api/sb-api.h
@@ -47,8 +47,11 @@ int api_register(string api_key, string name, string desc, string author,
  * @return 0 in case of success otherwise -1
  */
  struct message_params_object * api_run(string pluginlongtermpk,
-     string function_name, uint64_t callid, struct message_params_object args,
-     struct api_error *api_error);
+    string function_name, uint64_t callid, struct message_params_object args,
+    struct api_error *api_error);
+
+struct message_params_object * api_run_response(string pluginlongtermpk,
+    uint64_t callid, struct api_error *api_error);
 
 /**
  * Generates an API key using /dev/urandom. The length of the key

--- a/src/api/sb-api.h
+++ b/src/api/sb-api.h
@@ -57,3 +57,5 @@ int api_run(string api_key, string function_name, uint64_t callid,
  * @return 0 in case of success otherwise -1
  */
 int api_get_key(string key);
+
+int api_register_response(uint32_t msgid, msgpack_packer *pk);

--- a/src/api/sb-api.h
+++ b/src/api/sb-api.h
@@ -46,7 +46,7 @@ int api_register(string api_key, string name, string desc, string author,
  * @param[in] api_error   api_error instance
  * @return 0 in case of success otherwise -1
  */
-int api_run(string api_key, string function_name,
+int api_run(string api_key, string function_name, uint64_t callid,
     struct message_params_object args, msgpack_packer *pk,
     struct api_error *api_error);
 

--- a/src/api/sb-api.h
+++ b/src/api/sb-api.h
@@ -61,4 +61,5 @@ struct message_params_object * api_run_response(string pluginlongtermpk,
  */
 int api_get_key(string key);
 
-int api_register_response(uint32_t msgid, msgpack_packer *pk);
+struct message_params_object * api_register_response(
+    struct api_error *api_error);

--- a/src/api/sb-api.h
+++ b/src/api/sb-api.h
@@ -46,9 +46,9 @@ int api_register(string api_key, string name, string desc, string author,
  * @param[in] api_error   api_error instance
  * @return 0 in case of success otherwise -1
  */
-int api_run(string api_key, string function_name, uint64_t callid,
-    struct message_params_object args, msgpack_packer *pk,
-    struct api_error *api_error);
+ struct message_params_object * api_run(string pluginlongtermpk,
+     string function_name, uint64_t callid, struct message_params_object args,
+     struct api_error *api_error);
 
 /**
  * Generates an API key using /dev/urandom. The length of the key

--- a/src/hashmap-string.c
+++ b/src/hashmap-string.c
@@ -1,0 +1,83 @@
+/**
+ *    Copyright (C) 2015 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "sb-common.h"
+
+struct hashmap_string *hashmap_string_new()
+{
+  struct hashmap_string *hmap = MALLOC(struct hashmap_string);
+
+  if (hmap == NULL)
+    return (NULL);
+
+  hmap->table = kh_init(HASHMAP_STRING);
+
+  return (hmap);
+}
+
+
+void *hashmap_string_get(struct hashmap_string *hmap, string key)
+{
+  khiter_t i;
+
+  if ((i = kh_get(HASHMAP_STRING, hmap->table, key)) == kh_end(hmap->table))
+    return (NULL);
+
+  return (kh_val(hmap->table, i));
+}
+
+
+bool hashmap_string_contains_key(struct hashmap_string *hmap, string key)
+{
+  return (kh_get(HASHMAP_STRING, hmap->table, key) != kh_end(hmap->table));
+}
+
+
+void *hashmap_string_put(struct hashmap_string *hmap, string key, void *value)
+{
+  int ret;
+  void *retval = NULL;
+  khiter_t i = kh_put(HASHMAP_STRING, hmap->table, key, &ret);
+
+  if (!ret)
+    retval = kh_val(hmap->table, i);
+
+  kh_val(hmap->table, i) = value;
+
+  return (retval);
+}
+
+
+void *hashmap_string_remove(struct hashmap_string *hmap, string key)
+{
+  void *retval = NULL;
+  khiter_t i;
+
+  if ((i = kh_get(HASHMAP_STRING, hmap->table, key)) != kh_end(hmap->table)) {
+    retval = kh_val(hmap->table, i);
+    kh_del(HASHMAP_STRING, hmap->table, i);
+  }
+
+  return (retval);
+}
+
+
+void hashmap_string_free(struct hashmap_string *hmap)
+{
+  kh_clear(HASHMAP_STRING, hmap->table);
+  kh_destroy(HASHMAP_STRING, hmap->table);
+  FREE(hmap);
+}

--- a/src/hashmap-uint64.c
+++ b/src/hashmap-uint64.c
@@ -16,41 +16,41 @@
 
 #include "sb-common.h"
 
-struct hashmap *hashmap_new()
+struct hashmap_uint64 *hashmap_uint64_new()
 {
-  struct hashmap *hmap = MALLOC(struct hashmap);
+  struct hashmap_uint64 *hmap = MALLOC(struct hashmap_uint64);
 
   if (hmap == NULL)
     return (NULL);
 
-  hmap->table = kh_init(HASHMAP);
+  hmap->table = kh_init(HASHMAP_UINT64);
 
   return (hmap);
 }
 
 
-void *hashmap_get(struct hashmap *hmap, string key)
+void *hashmap_uint64_get(struct hashmap_uint64 *hmap, uint64_t key)
 {
   khiter_t i;
 
-  if ((i = kh_get(HASHMAP, hmap->table, key)) == kh_end(hmap->table))
+  if ((i = kh_get(HASHMAP_UINT64, hmap->table, key)) == kh_end(hmap->table))
     return (NULL);
 
   return (kh_val(hmap->table, i));
 }
 
 
-bool hashmap_contains_key(struct hashmap *hmap, string key)
+bool hashmap_uint64_contains_key(struct hashmap_uint64 *hmap, uint64_t key)
 {
-  return (kh_get(HASHMAP, hmap->table, key) != kh_end(hmap->table));
+  return (kh_get(HASHMAP_UINT64, hmap->table, key) != kh_end(hmap->table));
 }
 
 
-void *hashmap_put(struct hashmap *hmap, string key, void *value)
+void *hashmap_uint64_put(struct hashmap_uint64 *hmap, uint64_t key, void *value)
 {
   int ret;
   void *retval = NULL;
-  khiter_t i = kh_put(HASHMAP, hmap->table, key, &ret);
+  khiter_t i = kh_put(HASHMAP_UINT64, hmap->table, key, &ret);
 
   if (!ret)
     retval = kh_val(hmap->table, i);
@@ -61,23 +61,23 @@ void *hashmap_put(struct hashmap *hmap, string key, void *value)
 }
 
 
-void *hashmap_remove(struct hashmap *hmap, string key)
+void *hashmap_uint64_remove(struct hashmap_uint64 *hmap, uint64_t key)
 {
   void *retval = NULL;
   khiter_t i;
 
-  if ((i = kh_get(HASHMAP, hmap->table, key)) != kh_end(hmap->table)) {
+  if ((i = kh_get(HASHMAP_UINT64, hmap->table, key)) != kh_end(hmap->table)) {
     retval = kh_val(hmap->table, i);
-    kh_del(HASHMAP, hmap->table, i);
+    kh_del(HASHMAP_UINT64, hmap->table, i);
   }
 
   return (retval);
 }
 
 
-void hashmap_free(struct hashmap *hmap)
+void hashmap_uint64_free(struct hashmap_uint64 *hmap)
 {
-  kh_clear(HASHMAP, hmap->table);
-  kh_destroy(HASHMAP, hmap->table);
+  kh_clear(HASHMAP_UINT64, hmap->table);
+  kh_destroy(HASHMAP_UINT64, hmap->table);
   FREE(hmap);
 }

--- a/src/kvec.h
+++ b/src/kvec.h
@@ -1,0 +1,90 @@
+/* The MIT License
+
+   Copyright (c) 2008, by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "kvec.h"
+int main() {
+	kvec_t(int) array;
+	kv_init(array);
+	kv_push(int, array, 10); // append
+	kv_a(int, array, 20) = 5; // dynamic
+	kv_A(array, 20) = 4; // static
+	kv_destroy(array);
+	return 0;
+}
+*/
+
+/*
+  2008-09-22 (0.1.0):
+
+	* The initial version.
+
+*/
+
+#ifndef AC_KVEC_H
+#define AC_KVEC_H
+
+#include <stdlib.h>
+
+#define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+
+#define kvec_t(type) struct { size_t n, m; type *a; }
+#define kv_init(v) ((v).n = (v).m = 0, (v).a = 0)
+#define kv_destroy(v) free((v).a)
+#define kv_A(v, i) ((v).a[(i)])
+#define kv_pop(v) ((v).a[--(v).n])
+#define kv_size(v) ((v).n)
+#define kv_max(v) ((v).m)
+
+#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)realloc((v).a, sizeof(type) * (v).m))
+
+#define kv_copy(type, v1, v0) do {							\
+		if ((v1).m < (v0).n) kv_resize(type, v1, (v0).n);	\
+		(v1).n = (v0).n;									\
+		memcpy((v1).a, (v0).a, sizeof(type) * (v0).n);		\
+	} while (0)												\
+
+#define kv_push(type, v, x) do {									\
+		if ((v).n == (v).m) {										\
+			(v).m = (v).m? (v).m<<1 : 2;							\
+			(v).a = (type*)realloc((v).a, sizeof(type) * (v).m);	\
+		}															\
+		(v).a[(v).n++] = (x);										\
+	} while (0)
+
+#define kv_pushp(type, v) (((v).n == (v).m)?							\
+						   ((v).m = ((v).m? (v).m<<1 : 2),				\
+							(v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0)	\
+						   : 0), ((v).a + ((v).n++))
+
+#define kv_a(type, v, i) (((v).m <= (size_t)(i)? \
+						  ((v).m = (v).n = (i) + 1, kv_roundup32((v).m), \
+						   (v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0) \
+						  : (v).n <= (size_t)(i)? (v).n = (i) + 1 \
+						  : 0), (v).a[(i)])
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -25,10 +25,13 @@
 #define ENV_VAR_LISTEN_ADDRESS    "SPLONEBOX_LISTEN_ADDRESS"
 
 int8_t verbose_level;
+uv_loop_t loop;
 
 int main(int argc, char **argv)
 {
   optparser(argc, argv);
+
+  uv_loop_init(&loop);
 
   /* initialize libsodium */
   if (sodium_init() == -1) {
@@ -61,7 +64,7 @@ int main(int argc, char **argv)
     LOG_ERROR("Failed to start server.");
   }
 
-  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  uv_run(&loop, UV_RUN_DEFAULT);
 
   return (0);
 }

--- a/src/random.c
+++ b/src/random.c
@@ -1,0 +1,35 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <sodium.h>
+#include "sb-common.h"
+
+int64_t randommod(long long n)
+{
+  int64_t result = 0;
+  int64_t j;
+  unsigned char r[32];
+  if (n <= 1)
+    return 0;
+
+  randombytes(r,32);
+
+  for (j = 0; j < 32; ++j)
+    result = (int64_t)((uint64_t)(result * 256) + (uint64_t)r[j]) % n;
+
+  return result;
+}

--- a/src/rpc/connection/connection.c
+++ b/src/rpc/connection/connection.c
@@ -121,6 +121,8 @@ static void connection_close(struct connection *con)
   if (handle && !is_closing)
     uv_close(handle, close_cb);
 
+  kv_destroy(con->callvector);
+
   con->closed = 0;
 }
 

--- a/src/rpc/connection/connection.c
+++ b/src/rpc/connection/connection.c
@@ -37,8 +37,7 @@ static int connection_handle_request(struct connection *con,
     msgpack_object *obj);
 static int connection_handle_response(struct connection *con,
     msgpack_object *obj);
-static void connection_request_event(
-    struct connection_request_event_info *info);
+static void connection_request_event(connection_request_event_info *info);
 
 static msgpack_sbuffer sbuf;
 equeue *equeue_root;
@@ -156,7 +155,7 @@ static int connection_handle_request(struct connection *con,
 {
   struct dispatch_info *dispatcher = NULL;
   struct api_error api_error = { .isset = false };
-  struct connection_request_event_info eventinfo;
+  connection_request_event_info eventinfo;
   api_event event;
 
   if (!obj || !con)
@@ -200,8 +199,7 @@ static int connection_handle_request(struct connection *con,
 }
 
 
-static void connection_request_event(
-    struct connection_request_event_info *eventinfo)
+static void connection_request_event(connection_request_event_info *eventinfo)
 {
   char *data;
   msgpack_packer response;

--- a/src/rpc/connection/connection.c
+++ b/src/rpc/connection/connection.c
@@ -29,7 +29,7 @@
 #include "api/sb-api.h"
 #include "sb-common.h"
 
-static struct hashmap *connections = NULL;
+static struct hashmap_string *connections = NULL;
 static uint64_t id_cnt = 1;
 static void parse_cb(inputstream *istream, void *data, bool eof);
 static void close_cb(uv_handle_t *handle);
@@ -44,7 +44,7 @@ equeue *equeue_root;
 
 int connection_init(void)
 {
-  connections = hashmap_new();
+  connections = hashmap_string_new();
 
   if (dispatch_table_init() == -1)
     return (-1);

--- a/src/rpc/connection/connection.c
+++ b/src/rpc/connection/connection.c
@@ -201,25 +201,7 @@ static int connection_handle_request(struct connection *con,
 
 static void connection_request_event(connection_request_event_info *eventinfo)
 {
-  char *data;
-  msgpack_packer response;
-
-  msgpack_packer_init(&response, &sbuf, msgpack_sbuffer_write);
-  eventinfo->dispatcher->func(eventinfo->request, &response,
-      &eventinfo->api_error);
-
-  if (eventinfo->api_error.isset)
-    message_serialize_error_response(&response, &eventinfo->api_error,
-        eventinfo->request->msgid);
-
-  data = MALLOC_ARRAY(sbuf.size, char);
-
-  if (data == NULL)
-    return;
-
-  outputstream_write(eventinfo->con->streams.write, memcpy(data, sbuf.data,
-      sbuf.size), sbuf.size);
-  msgpack_sbuffer_clear(&sbuf);
+  eventinfo->dispatcher->func(eventinfo);
 
   FREE(eventinfo->request);
 }

--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -123,10 +123,8 @@ int handle_register(connection_request_event_info *info)
 
   functions = request->params.obj[1].data.params;
 
-  if (api_register(pluginlongtermpk, name, description, author, license, functions,
-      api_error)) {
-    return (-1);
-  }
+  api_register(pluginlongtermpk, name, description, author, license, functions,
+      api_error);
 
   /* TODO: pack status response */
 
@@ -135,11 +133,14 @@ int handle_register(connection_request_event_info *info)
    * connection hashmap
    */
 
+  if (api_error->isset)
+    return (-1);
+
   hashmap_string_put(connections, pluginlongtermpk, info->con);
 
-  //if (api_error->isset)
-    //message_serialize_error_response(&packer, api_error, request->msgid);
-    /*
+  msgpack_packer_init(&packer, &sbuf, msgpack_sbuffer_write);
+  api_register_response(info->request->msgid, &packer);
+
   data = MALLOC_ARRAY(sbuf.size, char);
 
   if (data == NULL)
@@ -149,7 +150,7 @@ int handle_register(connection_request_event_info *info)
       sbuf.size), sbuf.size);
 
   msgpack_sbuffer_clear(&sbuf);
-*/
+
   return (0);
 }
 
@@ -166,7 +167,7 @@ int handle_run(connection_request_event_info *info)
   struct message_request *request = info->request;
   struct api_error *api_error = &info->api_error;
 
-  if (!api_error )
+  if (!api_error)
     return (-1);
 
   /* check params size */

--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -132,13 +132,7 @@ int handle_register(connection_request_event_info *info)
    * connection hashmap
    */
   connection_hashmap_put(pluginlongtermpk, info->con);
-
-  params = CALLOC(1, struct message_params_object);
-
-  if (params == NULL)
-    return (-1);
-
-  params->size = 0;
+  params = api_register_response(api_error);
 
   connection_send_response(info->con, info->request->msgid, params,
       api_error);

--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -45,7 +45,7 @@ int handle_error(connection_request_event_info *info)
  */
 int handle_register(connection_request_event_info *info)
 {
-  struct message_params_object *meta;
+  struct message_params_object *meta = NULL;
   struct message_params_object functions;
   string pluginlongtermpk, name, description, author, license;
 
@@ -60,18 +60,16 @@ int handle_register(connection_request_event_info *info)
     return (-1);
 
   /* check params size */
-  if (request->params.size != 2) {
+  if (request->params.size != 2 && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid params params size");
-    return (-1);
   }
 
-  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY)
+  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY && !api_error->isset)
     meta = &request->params.obj[0].data.params;
   else {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. meta params has wrong type");
-    return (-1);
   }
 
   /*
@@ -79,35 +77,31 @@ int handle_register(connection_request_event_info *info)
    * [pluginlongtermpk, name, description, author, license]
    */
 
-  if (!meta) {
+  if (!meta && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. meta params is NULL");
-    return (-1);
   }
 
-  if (meta->size != 5) {
+  if (meta->size != 5 && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid meta params size");
-    return (-1);
   }
 
   /* extract meta information */
-  if ((meta->obj[0].type != OBJECT_TYPE_STR) ||
+  if (((meta->obj[0].type != OBJECT_TYPE_STR) ||
       (meta->obj[1].type != OBJECT_TYPE_STR) ||
       (meta->obj[2].type != OBJECT_TYPE_STR) ||
       (meta->obj[3].type != OBJECT_TYPE_STR) ||
-      (meta->obj[4].type != OBJECT_TYPE_STR)) {
+      (meta->obj[4].type != OBJECT_TYPE_STR)) && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. meta element has wrong type");
-    return (-1);
   }
 
-  if (!meta->obj[0].data.string.str || !meta->obj[1].data.string.str ||
+  if ((!meta->obj[0].data.string.str || !meta->obj[1].data.string.str ||
       !meta->obj[2].data.string.str || !meta->obj[3].data.string.str ||
-      !meta->obj[4].data.string.str) {
+      !meta->obj[4].data.string.str) && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid meta params size");
-    return (-1);
   }
 
   pluginlongtermpk = meta->obj[0].data.string;
@@ -116,10 +110,9 @@ int handle_register(connection_request_event_info *info)
   author = meta->obj[3].data.string;
   license = meta->obj[4].data.string;
 
-  if (request->params.obj[1].type != OBJECT_TYPE_ARRAY) {
+  if (request->params.obj[1].type != OBJECT_TYPE_ARRAY && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. functions has wrong type");
-    return (-1);
   }
 
   functions = request->params.obj[1].data.params;
@@ -140,7 +133,7 @@ int handle_register(connection_request_event_info *info)
 
   if (api_error->isset)
     message_serialize_error_response(&packer, api_error, request->msgid);
-
+    /*
   data = MALLOC_ARRAY(sbuf.size, char);
 
   if (data == NULL)
@@ -150,14 +143,14 @@ int handle_register(connection_request_event_info *info)
       sbuf.size), sbuf.size);
 
   msgpack_sbuffer_clear(&sbuf);
-
+*/
   return (0);
 }
 
 
 int handle_run(connection_request_event_info *info)
 {
-  struct message_params_object *meta;
+  struct message_params_object *meta = NULL;
   struct message_params_object args;
   string pluginlongtermpk, function_name;
   struct connection *con;
@@ -171,75 +164,90 @@ int handle_run(connection_request_event_info *info)
     return (-1);
 
   /* check params size */
-  if (request->params.size != 3) {
+  if (request->params.size != 3 && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. Invalid params params size");
-    return (-1);
   }
 
-  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY)
+  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY && !api_error->isset)
     meta = &request->params.obj[0].data.params;
   else {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta params has wrong type");
-    return (-1);
   }
 
-  if (!meta) {
+  if (!meta && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta params is NULL");
-    return (-1);
   }
 
-  if (meta->size != 1) {
+  /* meta = [pluginlongtermpk, nil]*/
+  if (meta->size != 2 && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. Invalid meta params size");
-    return (-1);
   }
 
   /* extract meta information */
-  if (meta->obj[0].type != OBJECT_TYPE_STR) {
+  if (meta->obj[0].type != OBJECT_TYPE_STR && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta elements have wrong type");
-    return (-1);
   }
 
-  if (!meta->obj[0].data.string.str) {
+  if (!meta->obj[0].data.string.str && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. Invalid meta params size");
-    return (-1);
   }
 
   pluginlongtermpk = meta->obj[0].data.string;
 
-  if (request->params.obj[1].type != OBJECT_TYPE_STR) {
+  if (meta->obj[1].type != OBJECT_TYPE_NIL && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
-        "Error dispatching run API request. function string has wrong type");
-    return (-1);
+        "Error dispatching run API request. meta elements have wrong type");
   }
 
-  if (!request->params.obj[1].data.string.str) {
+  if (request->params.obj[1].type != OBJECT_TYPE_STR && !api_error->isset) {
+    error_set(api_error, API_ERROR_TYPE_VALIDATION,
+        "Error dispatching run API request. function string has wrong type");
+  }
+
+  if (!request->params.obj[1].data.string.str && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid meta params size");
-    return (-1);
   }
 
   function_name = request->params.obj[1].data.string;
 
-  if (request->params.obj[2].type != OBJECT_TYPE_ARRAY) {
+  if (request->params.obj[2].type != OBJECT_TYPE_ARRAY && !api_error->isset) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. function string has wrong type");
-    return (-1);
   }
 
   args = request->params.obj[2].data.params;
 
   msgpack_packer_init(&packer, &sbuf, msgpack_sbuffer_write);
 
-  api_run(pluginlongtermpk, function_name, args, &packer, api_error);
+  con = hashmap_string_get(connections, pluginlongtermpk);
 
-  con = hashmap_get(connections, pluginlongtermpk);
+  /*
+   * if no connection is available for the key, set the connection to the
+   * the initial connection from the sender.
+   */
+  if (!con && !api_error->isset) {
+    error_set(api_error, API_ERROR_TYPE_VALIDATION, "plugin not registered");
+    con = info->con;
+  }
 
+  /*
+   * if a connection is available, generate a callid and save the connection in
+   * the callids hashmap with key callid.
+   */
+  if (!api_error->isset){
+    uint64_t callid = (uint64_t) randommod(281474976710656LL);
+    hashmap_uint64_put(callids, callid, con);
+    api_run(pluginlongtermpk, function_name, callid, args, &packer, api_error);
+  }
+
+  /* if error is set, generate an error response message */
   if (api_error->isset)
     message_serialize_error_response(&packer, api_error, request->msgid);
 

--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -49,27 +49,28 @@ int handle_register(connection_request_event_info *info)
   struct message_params_object functions;
   string pluginlongtermpk, name, description, author, license;
 
-  struct connection *con;
   char *data;
   msgpack_packer packer;
 
   struct message_request *request = info->request;
   struct api_error *api_error = &info->api_error;
 
-  if (!api_error)
+  if (!api_error || !request)
     return (-1);
 
   /* check params size */
-  if (request->params.size != 2 && !api_error->isset) {
+  if (request->params.size != 2) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid params params size");
+    return (-1);
   }
 
-  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY && !api_error->isset)
+  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY)
     meta = &request->params.obj[0].data.params;
   else {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. meta params has wrong type");
+    return (-1);
   }
 
   /*
@@ -77,31 +78,35 @@ int handle_register(connection_request_event_info *info)
    * [pluginlongtermpk, name, description, author, license]
    */
 
-  if (!meta && !api_error->isset) {
+  if (!meta) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. meta params is NULL");
+    return (-1);
   }
 
-  if (meta->size != 5 && !api_error->isset) {
+  if (meta->size != 5) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid meta params size");
+    return (-1);
   }
 
   /* extract meta information */
-  if (((meta->obj[0].type != OBJECT_TYPE_STR) ||
+  if ((meta->obj[0].type != OBJECT_TYPE_STR) ||
       (meta->obj[1].type != OBJECT_TYPE_STR) ||
       (meta->obj[2].type != OBJECT_TYPE_STR) ||
       (meta->obj[3].type != OBJECT_TYPE_STR) ||
-      (meta->obj[4].type != OBJECT_TYPE_STR)) && !api_error->isset) {
+      (meta->obj[4].type != OBJECT_TYPE_STR)) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. meta element has wrong type");
+    return (-1);
   }
 
-  if ((!meta->obj[0].data.string.str || !meta->obj[1].data.string.str ||
+  if (!meta->obj[0].data.string.str || !meta->obj[1].data.string.str ||
       !meta->obj[2].data.string.str || !meta->obj[3].data.string.str ||
-      !meta->obj[4].data.string.str) && !api_error->isset) {
+      !meta->obj[4].data.string.str) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid meta params size");
+    return (-1);
   }
 
   pluginlongtermpk = meta->obj[0].data.string;
@@ -110,9 +115,10 @@ int handle_register(connection_request_event_info *info)
   author = meta->obj[3].data.string;
   license = meta->obj[4].data.string;
 
-  if (request->params.obj[1].type != OBJECT_TYPE_ARRAY && !api_error->isset) {
+  if (request->params.obj[1].type != OBJECT_TYPE_ARRAY) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. functions has wrong type");
+    return (-1);
   }
 
   functions = request->params.obj[1].data.params;
@@ -131,8 +137,8 @@ int handle_register(connection_request_event_info *info)
 
   hashmap_string_put(connections, pluginlongtermpk, info->con);
 
-  if (api_error->isset)
-    message_serialize_error_response(&packer, api_error, request->msgid);
+  //if (api_error->isset)
+    //message_serialize_error_response(&packer, api_error, request->msgid);
     /*
   data = MALLOC_ARRAY(sbuf.size, char);
 
@@ -164,62 +170,72 @@ int handle_run(connection_request_event_info *info)
     return (-1);
 
   /* check params size */
-  if (request->params.size != 3 && !api_error->isset) {
+  if (request->params.size != 3) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. Invalid params params size");
+    return (-1);
   }
 
-  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY && !api_error->isset)
+  if (request->params.obj[0].type == OBJECT_TYPE_ARRAY)
     meta = &request->params.obj[0].data.params;
   else {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta params has wrong type");
+    return (-1);
   }
 
-  if (!meta && !api_error->isset) {
+  if (!meta) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta params is NULL");
+    return (-1);
   }
 
   /* meta = [pluginlongtermpk, nil]*/
-  if (meta->size != 2 && !api_error->isset) {
+  if (meta->size != 2) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. Invalid meta params size");
+    return (-1);
   }
 
   /* extract meta information */
-  if (meta->obj[0].type != OBJECT_TYPE_STR && !api_error->isset) {
+  if (meta->obj[0].type != OBJECT_TYPE_STR) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta elements have wrong type");
+    return (-1);
   }
 
-  if (!meta->obj[0].data.string.str && !api_error->isset) {
+  if (!meta->obj[0].data.string.str) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. Invalid meta params size");
+    return (-1);
   }
 
   pluginlongtermpk = meta->obj[0].data.string;
 
-  if (meta->obj[1].type != OBJECT_TYPE_NIL && !api_error->isset) {
+  if (meta->obj[1].type != OBJECT_TYPE_NIL) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta elements have wrong type");
+    return (-1);
   }
 
-  if (request->params.obj[1].type != OBJECT_TYPE_STR && !api_error->isset) {
+  if (request->params.obj[1].type != OBJECT_TYPE_STR) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. function string has wrong type");
+    return (-1);
   }
 
-  if (!request->params.obj[1].data.string.str && !api_error->isset) {
+  if (!request->params.obj[1].data.string.str) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching register API request. Invalid meta params size");
+    return (-1);
   }
 
   function_name = request->params.obj[1].data.string;
 
-  if (request->params.obj[2].type != OBJECT_TYPE_ARRAY && !api_error->isset) {
+  if (request->params.obj[2].type != OBJECT_TYPE_ARRAY) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. function string has wrong type");
+    return (-1);
   }
 
   args = request->params.obj[2].data.params;
@@ -232,24 +248,22 @@ int handle_run(connection_request_event_info *info)
    * if no connection is available for the key, set the connection to the
    * the initial connection from the sender.
    */
-  if (!con && !api_error->isset) {
+  if (!con) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION, "plugin not registered");
-    con = info->con;
+    return (-1);
   }
 
   /*
    * if a connection is available, generate a callid and save the connection in
    * the callids hashmap with key callid.
    */
-  if (!api_error->isset){
-    uint64_t callid = (uint64_t) randommod(281474976710656LL);
-    hashmap_uint64_put(callids, callid, con);
-    api_run(pluginlongtermpk, function_name, callid, args, &packer, api_error);
-  }
+  uint64_t callid = (uint64_t) randommod(281474976710656LL);
+  hashmap_uint64_put(callids, callid, con);
+  api_run(pluginlongtermpk, function_name, callid, args, &packer, api_error);
 
   /* if error is set, generate an error response message */
   if (api_error->isset)
-    message_serialize_error_response(&packer, api_error, request->msgid);
+    return (-1);
 
   data = MALLOC_ARRAY(sbuf.size, char);
 

--- a/src/rpc/connection/event.c
+++ b/src/rpc/connection/event.c
@@ -21,7 +21,6 @@
 
 equeue *equeue_root;
 
-static bool equeue_empty(equeue *queue);
 static queue_entry *dequeue_child(equeue *queue);
 static queue_entry *dequeue_child_from_root(equeue *queue);
 
@@ -57,7 +56,7 @@ equeue *equeue_new(equeue *root)
  *
  * @params queue queue instance
  */
-static bool equeue_empty(equeue *queue)
+bool equeue_empty(equeue *queue)
 {
   return (TAILQ_EMPTY(&queue->head));
 }

--- a/src/rpc/connection/server.c
+++ b/src/rpc/connection/server.c
@@ -51,7 +51,7 @@ struct server {
 
 static server_type type = SERVER_TYPE_TCP;
 
-static struct hashmap *servers = NULL;
+static struct hashmap_string *servers = NULL;
 
 static server_type server_get_endpoint_type(string endpoint,
     struct server *server);
@@ -61,7 +61,7 @@ static void server_free_cb(uv_handle_t *handle);
 
 int server_init(void)
 {
-  servers = hashmap_new();
+  servers = hashmap_string_new();
 
   if (!servers)
     return (-1);
@@ -80,7 +80,7 @@ int server_start(string endpoint)
     return (-1);
   }
 
-  if (hashmap_contains_key(servers, endpoint)) {
+  if (hashmap_string_contains_key(servers, endpoint)) {
     LOG("Already listening on %s", endpoint.str);
     return (-1);
   }
@@ -133,7 +133,7 @@ int server_start(string endpoint)
   server->type = type;
   stream->data = server;
 
-  hashmap_put(servers, endpoint, server);
+  hashmap_string_put(servers, endpoint, server);
 
   return (0);
 }
@@ -150,7 +150,7 @@ int server_close(void)
       uv_close((uv_handle_t *)&server->socket.pipe.handle, server_free_cb);
   });
 
-  hashmap_free(servers);
+  hashmap_string_free(servers);
 
   return (0);
 }
@@ -159,14 +159,14 @@ int server_stop(string endpoint)
 {
   struct server *server;
 
-  server = hashmap_get(servers, endpoint);
+  server = hashmap_string_get(servers, endpoint);
 
   if (server->type == SERVER_TYPE_TCP)
     uv_close((uv_handle_t *)&server->socket.tcp.handle, server_free_cb);
   else
     uv_close((uv_handle_t *)&server->socket.pipe.handle, server_free_cb);
 
-  hashmap_remove(servers, endpoint);
+  hashmap_string_remove(servers, endpoint);
 
   return (0);
 }

--- a/src/rpc/connection/server.c
+++ b/src/rpc/connection/server.c
@@ -59,6 +59,8 @@ static void connection_cb(uv_stream_t *server_stream, int status);
 static void client_free_cb(uv_handle_t *handle);
 static void server_free_cb(uv_handle_t *handle);
 
+uv_loop_t loop;
+
 int server_init(void)
 {
   servers = hashmap_string_new();
@@ -94,7 +96,7 @@ int server_start(string endpoint)
   uv_stream_t *stream = NULL;
 
   if (type == SERVER_TYPE_TCP) {
-    uv_tcp_init(uv_default_loop(), &server->socket.tcp.handle);
+    uv_tcp_init(&loop, &server->socket.tcp.handle);
     result = uv_tcp_bind(&server->socket.tcp.handle,
         (const struct sockaddr *)&server->socket.tcp.addr, 0);
 
@@ -111,7 +113,7 @@ int server_start(string endpoint)
       return (-1);
     }
 
-    uv_pipe_init(uv_default_loop(), &server->socket.pipe.handle, 0);
+    uv_pipe_init(&loop, &server->socket.pipe.handle, 0);
     result =
         uv_pipe_bind(&server->socket.pipe.handle, server->socket.pipe.addr);
 
@@ -244,9 +246,9 @@ static void connection_cb(uv_stream_t *server_stream, int status)
     return;
 
   if (server->type == SERVER_TYPE_TCP)
-    uv_tcp_init(uv_default_loop(), (uv_tcp_t *)client);
+    uv_tcp_init(&loop, (uv_tcp_t *)client);
   else
-    uv_pipe_init(uv_default_loop(), (uv_pipe_t *)client, 0);
+    uv_pipe_init(&loop, (uv_pipe_t *)client, 0);
 
   result = uv_accept(server_stream, client);
 

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -100,6 +100,27 @@ int message_serialize_error_response(msgpack_packer *pk,
 }
 
 
+int message_serialize_response(struct message_response *res,
+    msgpack_packer *pk)
+{
+  msgpack_pack_array(pk, 4);
+
+  if (pack_uint8(pk, MESSAGE_TYPE_RESPONSE) == -1)
+    return (-1);
+
+  if (pack_uint32(pk, res->msgid) == -1)
+    return (-1);
+
+  if (pack_nil(pk) == -1)
+    return (-1);
+
+  if (pack_params(pk, res->params) == -1)
+    return (-1);
+
+  return (0);
+}
+
+
 int message_serialize_request(struct message_request *req,
     msgpack_packer *pk)
 {

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -242,6 +242,8 @@ struct message_request *message_deserialize_request(msgpack_object *obj,
 static void free_message_object(message_object obj)
 {
   switch (obj.type) {
+  case OBJECT_TYPE_NIL:
+    break;
   case OBJECT_TYPE_INT:
     break;
   case OBJECT_TYPE_UINT:

--- a/src/rpc/msgpack/pack.c
+++ b/src/rpc/msgpack/pack.c
@@ -176,6 +176,9 @@ int pack_params(msgpack_packer *pk, struct message_params_object params)
     message_object_type type = object->type;
 
     switch (type) {
+    case (OBJECT_TYPE_NIL):
+      pack_nil(pk);
+      continue;
     case (OBJECT_TYPE_INT):
       pack_int64(pk, object->data.integer);
       continue;

--- a/src/rpc/msgpack/unpack.c
+++ b/src/rpc/msgpack/unpack.c
@@ -116,7 +116,8 @@ int unpack_params(msgpack_object *obj, struct message_params_object *params)
       elem->data.boolean = unpack_boolean(tmp);
       continue;
     case MSGPACK_OBJECT_NIL:
-      return (-1);
+      elem->type = OBJECT_TYPE_NIL;
+      continue;
     case MSGPACK_OBJECT_FLOAT:
       elem->type = OBJECT_TYPE_FLOAT;
       elem->data.floating = unpack_float(tmp);

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -32,6 +32,7 @@ typedef struct api_event api_event;
 typedef struct equeue equeue;
 typedef struct queue_entry queue_entry;
 typedef struct message_object message_object;
+typedef struct connection_request_event_info connection_request_event_info;
 
 
 #define MESSAGE_REQUEST_ARRAY_SIZE 4
@@ -156,8 +157,8 @@ struct connection_request_event_info {
 /* this structure holds the request event information and a callback to a
    handler function */
 struct api_event {
-  struct connection_request_event_info info;
-  void (*handler)(struct connection_request_event_info *info);
+  connection_request_event_info info;
+  void (*handler)(connection_request_event_info *info);
 };
 
 TAILQ_HEAD(queue, queue_entry);

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -115,6 +115,7 @@ struct message_response {
 
 struct connection {
   uint32_t msgid;
+  uint32_t pendingcalls;
   msgpack_unpacker *mpac;
   msgpack_sbuffer *sbuf;
   bool closed;
@@ -124,11 +125,7 @@ struct connection {
     outputstream *write;
     uv_stream_t *uv;
   } streams;
-  struct {
-    size_t n;
-    size_t m;
-    struct callinfo **a;
-  } callvector;
+  kvec_t(struct callinfo *) callvector;
 };
 
 struct callinfo {

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -94,9 +94,8 @@ struct message_request {
 };
 
 struct message_response {
-  uint8_t type;
   uint32_t msgid;
-  uint32_t status;
+  struct message_params_object params;
 };
 
 struct connection {
@@ -386,7 +385,9 @@ void free_params(struct message_params_object params);
 bool message_is_request(msgpack_object *obj);
 bool message_is_response(msgpack_object *obj);
 int message_serialize_error_response(msgpack_packer *pk, struct api_error *err,
-                                     uint32_t msgid);
+    uint32_t msgid);
+int message_serialize_response(struct message_response *res,
+    msgpack_packer *pk);
 struct message_request *message_deserialize_request(msgpack_object *obj,
                                                     struct api_error *err);
 int message_serialize_request(struct message_request *req, msgpack_packer *pk);

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -114,9 +114,7 @@ struct connection {
 
 struct dispatch_info {
   int (*func)(
-    struct message_request *request,
-    msgpack_packer *pk,
-    struct api_error *error
+    connection_request_event_info *info
     );
   bool async;
   string name;
@@ -377,12 +375,9 @@ int dispatch_table_init(void);
 int dispatch_table_free(void);
 struct dispatch_info *dispatch_table_get(string method);
 void dispatch_table_put(string method, struct dispatch_info *info);
-int handle_register(struct message_request *request, msgpack_packer *pk,
-    struct api_error *err);
-int handle_run(struct message_request *request, msgpack_packer *pk,
-    struct api_error *err);
-int handle_error(struct message_request *request, msgpack_packer *pk,
-    struct api_error *err);
+int handle_run(connection_request_event_info *info);
+int handle_register(connection_request_event_info *info);
+int handle_error(connection_request_event_info *info);
 
 
 /* Message Functions */

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -56,6 +56,7 @@ typedef struct connection_request_event_info connection_request_event_info;
 /* Enums */
 
 typedef enum {
+  OBJECT_TYPE_NIL,
   OBJECT_TYPE_INT,
   OBJECT_TYPE_UINT,
   OBJECT_TYPE_BOOL,

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -199,6 +199,12 @@ int connection_init(void);
  */
 int connection_create(uv_stream_t *stream);
 
+int connection_send_request(string pluginlongtermpk, string method,
+    struct message_params_object *params, struct api_error *api_error);
+int connection_send_response(string pluginlongtermpk, uint32_t msgid,
+    struct message_params_object *params, struct api_error *api_error);
+int connection_hashmap_put(string pluginlongtermpk, struct connection *con);
+
 /**
  * Create a new `outputstream` instance. A `outputstream` instance contains the
  * logic to write to a libuv stream

--- a/src/sb-common.h
+++ b/src/sb-common.h
@@ -23,9 +23,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <err.h>
+#include <uv.h>
 
 #include "queue.h"
 #include "khash.h"
+#include "kvec.h"
 
 /* Structs */
 #define API_ERROR_MESSAGE_LEN 512
@@ -47,6 +49,9 @@ struct api_error {
 
 /* verbosity global */
 extern int8_t verbose_level;
+
+/* uv loop global */
+extern uv_loop_t loop;
 
 /* Hashmap Functions */
 /* Must be declared before initializing KHASH */

--- a/src/sb-common.h
+++ b/src/sb-common.h
@@ -72,10 +72,17 @@ static inline bool string_eq(string a, string b)
 
 
 /* Init khash */
-KHASH_INIT(HASHMAP, string, void *, 1, string_djb2_hash, string_eq)
+KHASH_INIT(HASHMAP_STRING, string, void *, 1, string_djb2_hash, string_eq)
 
-struct hashmap {
-  khash_t(HASHMAP) *table;
+struct hashmap_string {
+  khash_t(HASHMAP_STRING) *table;
+};
+
+/* Init khash */
+KHASH_INIT(HASHMAP_UINT64, uint64_t, void *, 1, kh_int64_hash_func, kh_int64_hash_equal)
+
+struct hashmap_uint64 {
+  khash_t(HASHMAP_UINT64) *table;
 };
 /* Defines */
 
@@ -149,14 +156,65 @@ define UNUSED(x) x
  *
  * @return a pointer to the new instance
  */
-struct hashmap *hashmap_new(void);
+struct hashmap_string *hashmap_string_new(void);
+
+/**
+ * Free the memory of the `struct hashmap_string` instance
+ *
+ * @param the `struct hashmap_string` instance to free
+ */
+void hashmap_string_free(struct hashmap_string *hmap);
+
+/**
+ * Returns the value to whiche the specified key is mapped
+ *
+ * @param hmap The `struct hashmap_string` instance
+ * @param key The key whose associated value is to be returned
+ * @return The value to which the specified key is mapped, or null if this map
+ *         contains no mapping for the key
+ */
+void *hashmap_string_get(struct hashmap_string *hmap, string key);
+
+/**
+ * Returns true if this map contains a mapping for the specified key.
+ *
+ * @param hmap The `struct hashmap_string` instance
+ * @param key The key whose presence in this map is to be tested
+ * @return true if this map contains a mapping for the specified key, false
+ *         otherwise
+ */
+bool hashmap_string_contains_key(struct hashmap_string *hmap, string key);
+
+/**
+ * Associates the specified value with the specified key in this map
+ *
+ * @param hmap The `struct hashmap_string` instance
+ * @param key Key with which the specified value is to be associated
+ * @param value Value to be associated with the specified key
+ */
+void *hashmap_string_put(struct hashmap_string *hmap, string key, void *value);
+
+/**
+ * Remove the mapping for a key from this map if it is present
+ *
+ * @param key key whose mapping is to be deleted from the map
+ * @return The current value if exists or NULL otherwise
+ */
+void *hashmap_string_remove(struct hashmap_string *hmap, string key);
+
+/**
+ * Creates a new `struct map` instance
+ *
+ * @return a pointer to the new instance
+ */
+struct hashmap_uint64 *hashmap_uint64_new(void);
 
 /**
  * Free the memory of the `struct hashmap` instance
  *
  * @param the `struct hashmap` instance to free
  */
-void hashmap_free(struct hashmap *hmap);
+void hashmap_uint64_free(struct hashmap_uint64 *hmap);
 
 /**
  * Returns the value to whiche the specified key is mapped
@@ -166,7 +224,7 @@ void hashmap_free(struct hashmap *hmap);
  * @return The value to which the specified key is mapped, or null if this map
  *         contains no mapping for the key
  */
-void *hashmap_get(struct hashmap *hmap, string key);
+void *hashmap_uint64_get(struct hashmap_uint64 *hmap, uint64_t key);
 
 /**
  * Returns true if this map contains a mapping for the specified key.
@@ -176,7 +234,7 @@ void *hashmap_get(struct hashmap *hmap, string key);
  * @return true if this map contains a mapping for the specified key, false
  *         otherwise
  */
-bool hashmap_contains_key(struct hashmap *hmap, string key);
+bool hashmap_uint64_contains_key(struct hashmap_uint64 *hmap, uint64_t key);
 
 /**
  * Associates the specified value with the specified key in this map
@@ -185,7 +243,7 @@ bool hashmap_contains_key(struct hashmap *hmap, string key);
  * @param key Key with which the specified value is to be associated
  * @param value Value to be associated with the specified key
  */
-void *hashmap_put(struct hashmap *hmap, string key, void *value);
+void *hashmap_uint64_put(struct hashmap_uint64 *hmap, uint64_t key, void *value);
 
 /**
  * Remove the mapping for a key from this map if it is present
@@ -193,7 +251,7 @@ void *hashmap_put(struct hashmap *hmap, string key, void *value);
  * @param key key whose mapping is to be deleted from the map
  * @return The current value if exists or NULL otherwise
  */
-void *hashmap_remove(struct hashmap *hmap, string key);
+void *hashmap_uint64_remove(struct hashmap_uint64 *hmap, uint64_t key);
 
 
 void *reallocarray(void *optr, size_t nmemb, size_t size);
@@ -201,6 +259,8 @@ void *reallocarray(void *optr, size_t nmemb, size_t size);
 string cstring_to_string(char *str);
 string cstring_copy_string(const char *str);
 void free_string(string str);
+
+int64_t randommod(long long n);
 
 /**
  * The optparser parses the command line arguments. In case of an error,

--- a/test/unit/dispatch-handle-run.c
+++ b/test/unit/dispatch-handle-run.c
@@ -23,15 +23,22 @@
 
 void unit_dispatch_handle_run(UNUSED(void **state))
 {
+  connection_request_event_info info;
+
   struct message_params_object *meta, *arguments;
   struct api_error *err = MALLOC(struct api_error);
-  struct message_request *request = MALLOC(struct message_request);
+  struct message_request *request;
 
   string apikey = cstring_copy_string(
       "vBXBg3Wkq3ESULkYWtijxfS5UvBpWb-2mZHpKAKpyRuTmvdy4WR7cTJqz-vi2BA2");
   string function_name = cstring_copy_string("test_function");
   string arg1 = cstring_copy_string("test arg1");
   string arg2 = cstring_copy_string("test arg2");
+
+  info.request = MALLOC(struct message_request);
+  info.api_error = *err;
+
+  request = info.request;
 
   /* first level arrays:
    *
@@ -64,11 +71,11 @@ void unit_dispatch_handle_run(UNUSED(void **state))
   arguments->obj[1].data.string = arg2;
 
   /* check NULL pointer error */
-  assert_int_not_equal(0, handle_run(request, NULL, NULL));
+  assert_int_not_equal(0, handle_run(&info));
 
   /* object has wrong type */
   request->params.obj[0].type = OBJECT_TYPE_STR;
-  assert_int_not_equal(0, handle_run(request, NULL, err));
+  assert_int_not_equal(0, handle_run(&info));
 
   /* reset */
   request->params.obj[0].type = OBJECT_TYPE_ARRAY;
@@ -76,14 +83,14 @@ void unit_dispatch_handle_run(UNUSED(void **state))
   /* meta has wrong size */
   meta->size = 3;
 
-  assert_int_not_equal(0, handle_run(request, NULL, err));
+  assert_int_not_equal(0, handle_run(&info));
 
   /* reset */
   meta->size = 1;
 
   /* meta[0] has wrong type */
   meta->obj[0].type = OBJECT_TYPE_BIN;
-  assert_int_not_equal(0, handle_run(request, NULL, err));
+  assert_int_not_equal(0, handle_run(&info));
 
   free_params(request->params);
   FREE(request);


### PR DESCRIPTION
This PR finishes implementing the necessary infrastructure to send requests (`connection_send_request`) and handle response messages. The function which sends the requests blocks until the called plugin responds. This allows the core to forward calls like _run_ from plugin _a_ to plugin _b_. 

In detail the core generates a _call id_ upon receive of a `run` request. The core then sends
a request (forward) to the recipient which is identified by the `plugin long term key`. The core blocks until the call is answered. The blocking mechanism is implemented in the following way. After sending a request a new call information structure is stored in a vector. For this the _kvec.h_ library is used. The call information holds a boolean `hasresponse` condition variable which is initialized with `false`. We block on the condition in a while loop and check if new messages arrived. If a response message arrived the `msgid` is checked for equality and the block condition `hasresponse` is set to true.

Additionally the tests for handling `register` and `run` api calls have been updated.

For further information see #5 and #6.
