### PR TITLE
Issue #24

### DIFF
--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -173,7 +173,7 @@ int handle_run(connection_request_event_info *info)
     return (-1);
   }
 
-  if (!meta) {
+  if (!meta->obj) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API request. meta params is NULL");
     return (-1);


### PR DESCRIPTION
This fixes #24 

Since it's not possible for `meta` to become `NULL` we check for `meta->obj` since it could potentially be `NULL`

I say _potentially_ here because I don't know if the msgpack de-serialisation fails beforehand. This is from a "unit" perspective only. I can pass `handle_run` a `connection_request_event_info` containing a faulty request which will cause a segfault.  

**However:**
It could be, that `meta->obj` can't be `NULL` either. In this case the check can be dropped entirely.
