### PR TITLE
now api error returned by register is not overwritten anymore

### DIFF
--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -137,8 +137,11 @@ int handle_register(connection_request_event_info *info)
 
   if (api_register(pluginlongtermpk, name, description, author, license,
       functions, info->con, info->request->msgid, api_error) == -1) {
-    error_set(api_error, API_ERROR_TYPE_VALIDATION,
-        "Error running register API request.");
+
+    if (!api_error->isset)
+      error_set(api_error, API_ERROR_TYPE_VALIDATION,
+         "Error running register API request.");
+
     return (-1);
   }
 


### PR DESCRIPTION
Before: `api_error` is overwritten so that the real issues was hidden.
