### PR TITLE
Update message deserializer implementation and write tests for message_deserialize_request and message_deserialize_response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ set(TEST-SOURCES
   test/unit/message-deserialize-response.c
   test/unit/message-deserialize-error-response.c
   test/unit/message-serialize-request.c
+  test/unit/message-serialize-response.c
   test/functional/db-connect.c
   test/functional/db-plugin-add.c
   test/functional/db-apikey-verify.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ set(TEST-SOURCES
   test/unit/message-deserialize-request.c
   test/unit/message-deserialize-response.c
   test/unit/message-deserialize-error-response.c
+  test/unit/message-serialize-request.c
   test/functional/db-connect.c
   test/functional/db-plugin-add.c
   test/functional/db-apikey-verify.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ set(TEST-SOURCES
   test/unit/event-queue-get.c
   test/unit/message-deserialize-request.c
   test/unit/message-deserialize-response.c
+  test/unit/message-deserialize-error-response.c
   test/functional/db-connect.c
   test/functional/db-plugin-add.c
   test/functional/db-apikey-verify.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ set(TEST-SOURCES
   test/unit/message-deserialize-error-response.c
   test/unit/message-serialize-request.c
   test/unit/message-serialize-response.c
+  test/unit/message-serialize-error-response.c
   test/unit/message-is-request.c
   test/unit/message-is-response.c
   test/functional/db-connect.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,8 @@ set(TEST-SOURCES
   test/unit/dispatch-table-get.c
   test/unit/event-queue-put.c
   test/unit/event-queue-get.c
+  test/unit/message-deserialize-request.c
+  test/unit/message-deserialize-response.c
   test/functional/db-connect.c
   test/functional/db-plugin-add.c
   test/functional/db-apikey-verify.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,8 @@ set(TEST-SOURCES
   test/unit/message-deserialize-error-response.c
   test/unit/message-serialize-request.c
   test/unit/message-serialize-response.c
+  test/unit/message-is-request.c
+  test/unit/message-is-response.c
   test/functional/db-connect.c
   test/functional/db-plugin-add.c
   test/functional/db-apikey-verify.c

--- a/src/api/run.c
+++ b/src/api/run.c
@@ -85,7 +85,7 @@ int api_run(string pluginlongtermpk, string function_name, uint64_t callid,
   data->data.params = message_object_copy(args).data.params;
 
   /* send request */
-  run = (string) {.str = "run", .length = sizeof("run") - 1,};
+  run = (string) {.str = "run", .length = sizeof("run") - 1};
   cinfo = connection_send_request(pluginlongtermpk, run, run_params,
       api_error);
 

--- a/src/api/run.c
+++ b/src/api/run.c
@@ -95,15 +95,15 @@ int api_run(string pluginlongtermpk, string function_name, uint64_t callid,
       return (-1);
   }
 
-  if (cinfo->response == NULL || cinfo->response->params.size != 1) {
+  if (cinfo->response.params.size != 1) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API response. Either response is broken "
         "or it just has wrong params size.");
     return (-1);
   }
 
-  if (!(cinfo->response->params.obj[0].type == OBJECT_TYPE_UINT &&
-    callid == cinfo->response->params.obj[0].data.uinteger)) {
+  if (!(cinfo->response.params.obj[0].type == OBJECT_TYPE_UINT &&
+    callid == cinfo->response.params.obj[0].data.uinteger)) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error dispatching run API response. Invalid callid");
     return (-1);
@@ -118,8 +118,7 @@ int api_run(string pluginlongtermpk, string function_name, uint64_t callid,
     return (-1);
   };
 
-  free_params(cinfo->response->params);
-  FREE(cinfo->response);
+  free_params(cinfo->response.params);
   FREE(cinfo);
 
   return (0);

--- a/src/rpc/connection/connection.c
+++ b/src/rpc/connection/connection.c
@@ -307,7 +307,6 @@ struct callinfo * connection_send_request(string pluginlongtermpk, string method
     return (NULL);
   }
 
-  request.type = MESSAGE_TYPE_REQUEST;
   request.msgid = con->msgid++;
   request.method = method;
   request.params = params;

--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -271,7 +271,7 @@ int dispatch_teardown(void)
 int dispatch_table_init(void)
 {
   dispatch_info register_info = {.func = handle_register, .async = true,
-      .name = (string) {.str = "register", .length = sizeof("register") - 1,}};
+      .name = (string) {.str = "register", .length = sizeof("register") - 1}};
   dispatch_info run_info = {.func = handle_run, .async = true,
       .name = (string) {.str = "run", .length = sizeof("run") - 1}};
   dispatch_info error_info = {.func = handle_error, .async = true,

--- a/src/rpc/connection/dispatch.c
+++ b/src/rpc/connection/dispatch.c
@@ -42,7 +42,7 @@ static hashmap(uint64_t, ptr_t) *callids = NULL;
 
 int handle_error(connection_request_event_info *info)
 {
-  struct message_request *request = info->request;
+  struct message_request *request = &info->request;
   struct api_error *api_error = &info->api_error;
 
   if (!request || !api_error )
@@ -64,7 +64,7 @@ int handle_register(connection_request_event_info *info)
   array functions;
   string pluginlongtermpk, name, description, author, license;
 
-  struct message_request *request = info->request;
+  struct message_request *request = &info->request;
   struct api_error *api_error = &info->api_error;
 
   if (!api_error || !request)
@@ -136,7 +136,7 @@ int handle_register(connection_request_event_info *info)
   functions = request->params.obj[1].data.params;
 
   if (api_register(pluginlongtermpk, name, description, author, license,
-      functions, info->con, info->request->msgid, api_error) == -1) {
+      functions, info->con, info->request.msgid, api_error) == -1) {
 
     if (!api_error->isset)
       error_set(api_error, API_ERROR_TYPE_VALIDATION,
@@ -158,7 +158,7 @@ int handle_run(connection_request_event_info *info)
   struct message_request *request;
   struct api_error *api_error;
 
-  request = info->request;
+  request = &info->request;
   api_error = &info->api_error;
 
   if (!api_error || !request)
@@ -238,7 +238,7 @@ int handle_run(connection_request_event_info *info)
   hashmap_put(uint64_t, ptr_t)(callids, callid, info->con);
 
   if (api_run(pluginlongtermpk, function_name, callid, args_object, info->con,
-      info->request->msgid, api_error) == -1) {
+      info->request.msgid, api_error) == -1) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Error executing run API request.");
     return (-1);
@@ -273,7 +273,9 @@ int dispatch_table_init(void)
   dispatch_info register_info = {.func = handle_register, .async = true,
       .name = (string) {.str = "register", .length = sizeof("register") - 1,}};
   dispatch_info run_info = {.func = handle_run, .async = true,
-      .name = (string) {.str = "run", .length = sizeof("run") - 1,}};
+      .name = (string) {.str = "run", .length = sizeof("run") - 1}};
+  dispatch_info error_info = {.func = handle_error, .async = true,
+      .name = (string) {.str = "error", .length = sizeof("error") - 1}};
 
   msgpack_sbuffer_init(&sbuf);
 
@@ -285,6 +287,7 @@ int dispatch_table_init(void)
 
   dispatch_table_put(register_info.name, register_info);
   dispatch_table_put(run_info.name, run_info);
+  dispatch_table_put(error_info.name, error_info);
 
   return (0);
 }

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -149,7 +149,10 @@ int message_deserialize_request(struct message_request *req,
   uint64_t tmp_type;
   uint64_t tmp_msgid;
 
-  if (!req || !obj || !api_error) {
+  if (!api_error)
+    return (-1);
+
+  if (!req || !obj) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION, "Error");
     return (-1);
   }
@@ -252,7 +255,10 @@ int message_deserialize_response(struct message_response *res,
   msgpack_object *type, *msgid, *params;
   uint64_t tmp_msgid;
 
-  if (!obj || !res || !api_error) {
+  if (!api_error)
+    return (-1);
+
+  if (!res || !obj) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION, "Error");
     return (-1);
   }
@@ -325,7 +331,10 @@ int message_deserialize_error_response(struct message_response *res,
   msgpack_object *type, *msgid, *params;
   uint64_t tmp_msgid;
 
-  if (!obj || !res || !api_error) {
+  if (!api_error)
+    return (-1);
+
+  if (!res || !obj) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION, "Error");
     return (-1);
   }
@@ -385,9 +394,12 @@ int message_deserialize_error_response(struct message_response *res,
 
   /* nil */
   if (obj->via.array.ptr[3].type != MSGPACK_OBJECT_NIL) {
+    free_params(res->params);
     error_set(api_error, API_ERROR_TYPE_VALIDATION, "nil field has wrong type");
     return (-1);
   }
+
+  return (0);
 }
 
 

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -61,13 +61,13 @@ int message_serialize_error_response(msgpack_packer *pk,
   struct message_object *err_data;
   array err_array;
 
+  if (!pk || !api_error || !api_error->isset)
+    return (-1);
+
   msgpack_pack_array(pk, 4);
 
-  if (pack_uint8(pk, MESSAGE_TYPE_RESPONSE) == -1)
-    return (-1);
-
-  if (pack_uint32(pk, msgid) == -1)
-    return (-1);
+  pack_uint8(pk, MESSAGE_TYPE_RESPONSE);
+  pack_uint32(pk, msgid);
 
   err_array.size = 2;
   err_array.obj = CALLOC(2, struct message_object);
@@ -93,10 +93,11 @@ int message_serialize_error_response(msgpack_packer *pk,
   if (pack_params(pk, err_array) == -1)
     return (-1);
 
-  if (pack_nil(pk) == -1)
-    return (-1);
+  pack_nil(pk);
 
-  return (true);
+  FREE(err_array.obj);
+
+  return (0);
 }
 
 

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -108,11 +108,8 @@ int message_serialize_response(struct message_response *res,
   if (pack_uint8(pk, MESSAGE_TYPE_RESPONSE) == -1)
     return (-1);
 
-  if (pack_uint32(pk, res->msgid) == -1)
-    return (-1);
-
-  if (pack_nil(pk) == -1)
-    return (-1);
+  pack_uint32(pk, res->msgid);
+  pack_nil(pk);
 
   if (pack_params(pk, res->params) == -1)
     return (-1);
@@ -134,7 +131,7 @@ int message_serialize_request(struct message_request *req,
   if (req->method.str == NULL || (pack_string(pk, req->method) == -1))
     return (-1);
 
-  if (req->params.obj == NULL || (pack_params(pk, req->params) == -1))
+  if (pack_params(pk, req->params) == -1)
     return (-1);
 
   return (0);
@@ -174,8 +171,6 @@ int message_deserialize_request(struct message_request *req,
     error_set(api_error, API_ERROR_TYPE_VALIDATION, "type must be 0 or 1");
     return (-1);
   }
-
-  req->type = (uint8_t)tmp_type;
 
   /* message id */
   msgid = &obj->via.array.ptr[1];

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -126,16 +126,15 @@ int message_serialize_request(struct message_request *req,
 {
   msgpack_pack_array(pk, 4);
 
-  if (pack_uint8(pk, req->type) == -1)
+  if (pack_uint8(pk, MESSAGE_TYPE_REQUEST) == -1)
     return (-1);
 
-  if (pack_uint32(pk, req->msgid) == -1)
+  pack_uint32(pk, req->msgid);
+
+  if (req->method.str == NULL || (pack_string(pk, req->method) == -1))
     return (-1);
 
-  if (pack_string(pk, req->method) == -1)
-    return (-1);
-
-  if (pack_params(pk, req->params) == -1)
+  if (req->params.obj == NULL || (pack_params(pk, req->params) == -1))
     return (-1);
 
   return (0);

--- a/src/rpc/msgpack/message.c
+++ b/src/rpc/msgpack/message.c
@@ -103,11 +103,11 @@ int message_serialize_error_response(msgpack_packer *pk,
 int message_serialize_response(struct message_response *res,
     msgpack_packer *pk)
 {
-  msgpack_pack_array(pk, 4);
-
-  if (pack_uint8(pk, MESSAGE_TYPE_RESPONSE) == -1)
+  if (!pk || !res)
     return (-1);
 
+  msgpack_pack_array(pk, 4);
+  pack_uint8(pk, MESSAGE_TYPE_RESPONSE);
   pack_uint32(pk, res->msgid);
   pack_nil(pk);
 
@@ -121,11 +121,11 @@ int message_serialize_response(struct message_response *res,
 int message_serialize_request(struct message_request *req,
     msgpack_packer *pk)
 {
-  msgpack_pack_array(pk, 4);
-
-  if (pack_uint8(pk, MESSAGE_TYPE_REQUEST) == -1)
+  if (!pk || !req)
     return (-1);
 
+  msgpack_pack_array(pk, 4);
+  pack_uint8(pk, MESSAGE_TYPE_REQUEST);
   pack_uint32(pk, req->msgid);
 
   if (req->method.str == NULL || (pack_string(pk, req->method) == -1))

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -58,9 +58,6 @@ typedef struct connection_request_event_info connection_request_event_info;
 #define MESSAGE_RESPONSE_UNKNOWN UINT32_MAX
 #define MESSAGE_APIKEY_LENGTH 64
 
-#define ARRAY_INIT {.size = 0, .capacity = 0, .obj = NULL}
-#define ERROR_INIT {.isset = false}
-
 #define STREAM_BUFFER_SIZE 0xffff
 
 

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -164,7 +164,7 @@ struct callinfo {
   uint32_t msgid;
   bool hasresponse;
   bool errorresponse;
-  struct message_response *response;
+  struct message_response response;
 };
 
 typedef struct {
@@ -202,7 +202,7 @@ struct inputstream {
 /* this structure holds a request and all information to send a response */
 struct connection_request_event_info {
   struct connection *con;
-  struct message_request *request;
+  struct message_request request;
   dispatch_info dispatcher;
   struct api_error api_error;
 };
@@ -472,12 +472,12 @@ int message_serialize_error_response(msgpack_packer *pk, struct api_error *err,
     uint32_t msgid);
 int message_serialize_response(struct message_response *res,
     msgpack_packer *pk);
-struct message_request *message_deserialize_request(msgpack_object *obj,
-                                                    struct api_error *err);
-struct message_response *message_deserialize_response(msgpack_object *obj,
-    struct api_error *api_error);
-struct message_response *message_deserialize_error_response(msgpack_object *obj,
-    struct api_error *api_error);
+int message_deserialize_request(struct message_request *req,
+    msgpack_object *obj, struct api_error *api_error);
+int message_deserialize_response(struct message_response *res,
+    msgpack_object *obj, struct api_error *api_error);
+int message_deserialize_error_response(struct message_response *res,
+    msgpack_object *obj, struct api_error *api_error);
 int message_serialize_request(struct message_request *req, msgpack_packer *pk);
 void message_dispatch(msgpack_object *req, msgpack_packer *res);
 uint64_t message_get_id(msgpack_object *obj);

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -110,7 +110,6 @@ struct message_object {
 };
 
 struct message_request {
-  uint8_t type;
   uint32_t msgid;
   string method;
   array params;

--- a/src/sb-common.h
+++ b/src/sb-common.h
@@ -191,6 +191,10 @@ define UNUSED(x) x
 #define ANSI_COLOR_CYAN    "\x1b[36m"
 #define ANSI_COLOR_RESET   "\x1b[0m"
 
+#define ARRAY_INIT {.size = 0, .capacity = 0, .obj = NULL}
+#define STRING_INIT {.str = NULL, .length = 0}
+#define ERROR_INIT {.isset = false}
+
 /* Functions */
 void *reallocarray(void *optr, size_t nmemb, size_t size);
 

--- a/src/string.c
+++ b/src/string.c
@@ -36,7 +36,7 @@ string cstring_copy_string(const char *str)
   char *ret;
 
   if (!str)
-    return (string) {.str = NULL, .length = 0};
+    return (string) STRING_INIT;
 
   length = strlen(str);
   ret = MALLOC_ARRAY(length + 1, char);

--- a/test/functional/dispatch-handle-register.c
+++ b/test/functional/dispatch-handle-register.c
@@ -70,10 +70,9 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   string author = cstring_copy_string("test");
   string license = cstring_copy_string("none");
 
-  info.request = MALLOC(struct message_request);
-  info.request->msgid = 1;
+  info.request.msgid = 1;
 
-  request = info.request;
+  request = &info.request;
   assert_non_null(request);
 
   info.api_error = *err;
@@ -262,7 +261,6 @@ void functional_dispatch_handle_register(UNUSED(void **state))
 
   free_params(request->params);
   connection_teardown();
-  FREE(request);
   FREE(err);
   db_close();
 }

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -35,6 +35,7 @@ void unit_message_deserialize_request(void **state);
 void unit_message_deserialize_response(void **state);
 void unit_message_deserialize_error_response(void **state);
 void unit_message_serialize_request(void **state);
+void unit_message_serialize_response(void **state);
 
 
 void functional_client_connect(void **state);
@@ -69,6 +70,7 @@ const struct CMUnitTest tests[] = {
   cmocka_unit_test(unit_message_deserialize_response),
   cmocka_unit_test(unit_message_deserialize_error_response),
   cmocka_unit_test(unit_message_serialize_request),
+  cmocka_unit_test(unit_message_serialize_response),
   cmocka_unit_test(functional_db_connect),
   cmocka_unit_test(functional_db_plugin_add),
   cmocka_unit_test(functional_db_apikey_add),

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -33,6 +33,7 @@ void unit_event_queue_get(void **state);
 void unit_regression_issue_60(void **state);
 void unit_message_deserialize_request(void **state);
 void unit_message_deserialize_response(void **state);
+void unit_message_deserialize_error_response(void **state);
 
 
 void functional_client_connect(void **state);
@@ -65,6 +66,7 @@ const struct CMUnitTest tests[] = {
   cmocka_unit_test(unit_event_queue_put),
   cmocka_unit_test(unit_message_deserialize_request),
   cmocka_unit_test(unit_message_deserialize_response),
+  cmocka_unit_test(unit_message_deserialize_error_response),
   cmocka_unit_test(functional_db_connect),
   cmocka_unit_test(functional_db_plugin_add),
   cmocka_unit_test(functional_db_apikey_add),

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -36,6 +36,7 @@ void unit_message_deserialize_response(void **state);
 void unit_message_deserialize_error_response(void **state);
 void unit_message_serialize_request(void **state);
 void unit_message_serialize_response(void **state);
+void unit_message_serialize_error_response(void **state);
 void unit_message_is_request(void **state);
 void unit_message_is_response(void **state);
 
@@ -73,6 +74,7 @@ const struct CMUnitTest tests[] = {
   cmocka_unit_test(unit_message_deserialize_error_response),
   cmocka_unit_test(unit_message_serialize_request),
   cmocka_unit_test(unit_message_serialize_response),
+  cmocka_unit_test(unit_message_serialize_error_response),
   cmocka_unit_test(unit_message_is_request),
   cmocka_unit_test(unit_message_is_response),
   cmocka_unit_test(functional_db_connect),

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -31,6 +31,8 @@ void unit_dispatch_table_get(void **state);
 void unit_event_queue_put(void **state);
 void unit_event_queue_get(void **state);
 void unit_regression_issue_60(void **state);
+void unit_message_deserialize_request(void **state);
+void unit_message_deserialize_response(void **state);
 
 
 void functional_client_connect(void **state);
@@ -61,6 +63,8 @@ const struct CMUnitTest tests[] = {
   cmocka_unit_test(unit_api_get_key),
   cmocka_unit_test(unit_event_queue_put),
   cmocka_unit_test(unit_event_queue_put),
+  cmocka_unit_test(unit_message_deserialize_request),
+  cmocka_unit_test(unit_message_deserialize_response),
   cmocka_unit_test(functional_db_connect),
   cmocka_unit_test(functional_db_plugin_add),
   cmocka_unit_test(functional_db_apikey_add),

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -36,6 +36,8 @@ void unit_message_deserialize_response(void **state);
 void unit_message_deserialize_error_response(void **state);
 void unit_message_serialize_request(void **state);
 void unit_message_serialize_response(void **state);
+void unit_message_is_request(void **state);
+void unit_message_is_response(void **state);
 
 
 void functional_client_connect(void **state);
@@ -71,6 +73,8 @@ const struct CMUnitTest tests[] = {
   cmocka_unit_test(unit_message_deserialize_error_response),
   cmocka_unit_test(unit_message_serialize_request),
   cmocka_unit_test(unit_message_serialize_response),
+  cmocka_unit_test(unit_message_is_request),
+  cmocka_unit_test(unit_message_is_response),
   cmocka_unit_test(functional_db_connect),
   cmocka_unit_test(functional_db_plugin_add),
   cmocka_unit_test(functional_db_apikey_add),

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -34,6 +34,7 @@ void unit_regression_issue_60(void **state);
 void unit_message_deserialize_request(void **state);
 void unit_message_deserialize_response(void **state);
 void unit_message_deserialize_error_response(void **state);
+void unit_message_serialize_request(void **state);
 
 
 void functional_client_connect(void **state);
@@ -67,6 +68,7 @@ const struct CMUnitTest tests[] = {
   cmocka_unit_test(unit_message_deserialize_request),
   cmocka_unit_test(unit_message_deserialize_response),
   cmocka_unit_test(unit_message_deserialize_error_response),
+  cmocka_unit_test(unit_message_serialize_request),
   cmocka_unit_test(functional_db_connect),
   cmocka_unit_test(functional_db_plugin_add),
   cmocka_unit_test(functional_db_apikey_add),

--- a/test/unit/message-deserialize-request.c
+++ b/test/unit/message-deserialize-request.c
@@ -1,0 +1,119 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <msgpack.h>
+
+#include "sb-common.h"
+#include "rpc/msgpack/sb-msgpack-rpc.h"
+#include "helper-unix.h"
+
+
+void unit_message_deserialize_request(UNUSED(void **state))
+{
+  struct api_error error = ERROR_INIT;
+  msgpack_sbuffer sbuf;
+  msgpack_packer pk;
+  msgpack_zone mempool;
+  msgpack_object deserialized;
+  struct message_request request;
+
+  msgpack_sbuffer_init(&sbuf);
+  msgpack_zone_init(&mempool, 2048);
+
+  /* positiv test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_str(&pk, 4);
+  msgpack_pack_str_body(&pk, "test", 4);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  free_string(request.method);
+  free_params(request.params);
+
+  /* wrong type */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_str(&pk, 4);
+  msgpack_pack_str_body(&pk, "test", 4);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong msgid */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_int(&pk, -1234);
+  msgpack_pack_str(&pk, 4);
+  msgpack_pack_str_body(&pk, "test", 4);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong method */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_int(&pk, 1234);
+  msgpack_pack_nil(&pk);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong params */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_int(&pk, 1234);
+  msgpack_pack_str(&pk, 4);
+  msgpack_pack_str_body(&pk, "test", 4);
+  msgpack_pack_nil(&pk);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  msgpack_zone_destroy(&mempool);
+  msgpack_sbuffer_destroy(&sbuf);
+}

--- a/test/unit/message-deserialize-request.c
+++ b/test/unit/message-deserialize-request.c
@@ -52,6 +52,20 @@ void unit_message_deserialize_request(UNUSED(void **state))
   free_string(request.method);
   free_params(request.params);
 
+  /* wrong type type*/
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_nil(&pk);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_str(&pk, 4);
+  msgpack_pack_str_body(&pk, "test", 4);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
   /* wrong type */
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
   msgpack_pack_array(&pk, 4);
@@ -73,6 +87,22 @@ void unit_message_deserialize_request(UNUSED(void **state))
   msgpack_pack_array(&pk, 4);
   msgpack_pack_uint8(&pk, 0);
   msgpack_pack_int(&pk, -1234);
+  msgpack_pack_str(&pk, 4);
+  msgpack_pack_str_body(&pk, "test", 4);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong msgid value*/
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint32(&pk, UINT32_MAX);
   msgpack_pack_str(&pk, 4);
   msgpack_pack_str_body(&pk, "test", 4);
   msgpack_pack_array(&pk, 1);
@@ -113,6 +143,14 @@ void unit_message_deserialize_request(UNUSED(void **state))
       &error));
 
   msgpack_sbuffer_clear(&sbuf);
+
+  /* null input params */
+  assert_int_not_equal(0, message_deserialize_request(&request, &deserialized,
+      NULL));
+  assert_int_not_equal(0, message_deserialize_request(&request, NULL,
+      &error));
+  assert_int_not_equal(0, message_deserialize_request(NULL, &deserialized,
+      &error));
 
   msgpack_zone_destroy(&mempool);
   msgpack_sbuffer_destroy(&sbuf);

--- a/test/unit/message-deserialize-response.c
+++ b/test/unit/message-deserialize-response.c
@@ -1,0 +1,114 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <msgpack.h>
+
+#include "sb-common.h"
+#include "rpc/msgpack/sb-msgpack-rpc.h"
+#include "helper-unix.h"
+
+
+void unit_message_deserialize_response(UNUSED(void **state))
+{
+  struct api_error error = ERROR_INIT;
+  msgpack_sbuffer sbuf;
+  msgpack_packer pk;
+  msgpack_zone mempool;
+  msgpack_object deserialized;
+  struct message_response response;
+
+  msgpack_sbuffer_init(&sbuf);
+  msgpack_zone_init(&mempool, 2048);
+
+  /* positiv test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_nil(&pk);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_equal(0, message_deserialize_response(&response, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  free_params(response.params);
+
+  /* wrong type */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_nil(&pk);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_response(&response, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong msgid */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_int(&pk, -1234);
+  msgpack_pack_nil(&pk);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_response(&response, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong nil */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_array(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_response(&response, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong params */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint32(&pk, 1234);
+  msgpack_pack_nil(&pk);
+  msgpack_pack_nil(&pk);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_int_not_equal(0, message_deserialize_response(&response, &deserialized,
+      &error));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  msgpack_zone_destroy(&mempool);
+  msgpack_sbuffer_destroy(&sbuf);
+}

--- a/test/unit/message-is-request.c
+++ b/test/unit/message-is-request.c
@@ -1,0 +1,77 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <msgpack.h>
+
+#include "sb-common.h"
+#include "rpc/msgpack/sb-msgpack-rpc.h"
+#include "helper-unix.h"
+
+
+void unit_message_is_request(UNUSED(void **state))
+{
+  struct api_error error = ERROR_INIT;
+  msgpack_sbuffer sbuf;
+  msgpack_packer pk;
+  msgpack_zone mempool;
+  msgpack_object deserialized;
+
+  msgpack_sbuffer_init(&sbuf);
+  msgpack_zone_init(&mempool, 2048);
+
+  /* positiv test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_true(message_is_request(&deserialized));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong type test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_false(message_is_request(&deserialized));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* no array test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_false(message_is_request(&deserialized));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* NULL test */
+  assert_false(message_is_request(NULL));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  msgpack_zone_destroy(&mempool);
+  msgpack_sbuffer_destroy(&sbuf);
+}

--- a/test/unit/message-is-response.c
+++ b/test/unit/message-is-response.c
@@ -1,0 +1,77 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <msgpack.h>
+
+#include "sb-common.h"
+#include "rpc/msgpack/sb-msgpack-rpc.h"
+#include "helper-unix.h"
+
+
+void unit_message_is_response(UNUSED(void **state))
+{
+  struct api_error error = ERROR_INIT;
+  msgpack_sbuffer sbuf;
+  msgpack_packer pk;
+  msgpack_zone mempool;
+  msgpack_object deserialized;
+
+  msgpack_sbuffer_init(&sbuf);
+  msgpack_zone_init(&mempool, 2048);
+
+  /* positiv test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_true(message_is_response(&deserialized));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* wrong type test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_array(&pk, 4);
+  msgpack_pack_uint8(&pk, 0);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_false(message_is_response(&deserialized));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* no array test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  msgpack_pack_uint8(&pk, 1);
+  msgpack_unpack(sbuf.data, sbuf.size, NULL, &mempool, &deserialized);
+
+  assert_false(message_is_response(&deserialized));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* NULL test */
+  assert_false(message_is_response(NULL));
+
+  msgpack_sbuffer_clear(&sbuf);
+
+  msgpack_zone_destroy(&mempool);
+  msgpack_sbuffer_destroy(&sbuf);
+}

--- a/test/unit/message-serialize-error-response.c
+++ b/test/unit/message-serialize-error-response.c
@@ -1,0 +1,43 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <msgpack.h>
+
+#include "sb-common.h"
+#include "rpc/msgpack/sb-msgpack-rpc.h"
+#include "helper-unix.h"
+
+
+void unit_message_serialize_error_response(UNUSED(void **state))
+{
+  msgpack_sbuffer sbuf;
+  struct api_error error = ERROR_INIT;
+  msgpack_packer pk;
+
+  error_set(&error, API_ERROR_TYPE_VALIDATION, "test error");
+
+  msgpack_sbuffer_init(&sbuf);
+
+  /* positiv test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  assert_int_equal(0, message_serialize_error_response(&pk, &error, 1234));
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* null check */
+  assert_int_not_equal(0, message_serialize_error_response(NULL, NULL, 1234));
+
+  msgpack_sbuffer_destroy(&sbuf);
+}

--- a/test/unit/message-serialize-request.c
+++ b/test/unit/message-serialize-request.c
@@ -37,7 +37,6 @@ void unit_message_serialize_request(UNUSED(void **state))
 
   /* positiv test */
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  request.type = MESSAGE_TYPE_REQUEST;
   request.msgid = 1234;
   request.method = (string) {.str = "test method",
       .length = sizeof("test method") - 1};
@@ -47,7 +46,6 @@ void unit_message_serialize_request(UNUSED(void **state))
 
   /* no valid string */
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  request.type = MESSAGE_TYPE_RESPONSE;
   request.msgid = 1234;
   request.method = (string) STRING_INIT;
   request.params = params;
@@ -56,15 +54,21 @@ void unit_message_serialize_request(UNUSED(void **state))
 
   free_params(request.params);
 
+  params.size = 1;
+  params.obj = CALLOC(1, struct message_object);
+  params.obj[0].type = 1000;
+  params.obj[0].data.uinteger = 1234;
+
   /* no valid params */
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  request.type = MESSAGE_TYPE_RESPONSE;
   request.msgid = 1234;
   request.method = (string) {.str = "test method",
       .length = sizeof("test method") - 1};
-  request.params = (array) ARRAY_INIT;
+  request.params = params;
   assert_int_not_equal(0, message_serialize_request(&request, &pk));
   msgpack_sbuffer_clear(&sbuf);
+
+  free_params(request.params);
 
   msgpack_sbuffer_destroy(&sbuf);
 }

--- a/test/unit/message-serialize-request.c
+++ b/test/unit/message-serialize-request.c
@@ -1,0 +1,70 @@
+/**
+ *    Copyright (C) 2016 splone UG
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <msgpack.h>
+
+#include "sb-common.h"
+#include "rpc/msgpack/sb-msgpack-rpc.h"
+#include "helper-unix.h"
+
+
+void unit_message_serialize_request(UNUSED(void **state))
+{
+  msgpack_sbuffer sbuf;
+  msgpack_packer pk;
+  struct message_request request;
+  array params;
+
+  params.size = 1;
+  params.obj = CALLOC(1, struct message_object);
+  params.obj[0].type = OBJECT_TYPE_UINT;
+  params.obj[0].data.uinteger = 1234;
+
+  msgpack_sbuffer_init(&sbuf);
+
+  /* positiv test */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  request.type = MESSAGE_TYPE_REQUEST;
+  request.msgid = 1234;
+  request.method = (string) {.str = "test method",
+      .length = sizeof("test method") - 1};
+  request.params = params;
+  assert_int_equal(0, message_serialize_request(&request, &pk));
+  msgpack_sbuffer_clear(&sbuf);
+
+  /* no valid string */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  request.type = MESSAGE_TYPE_RESPONSE;
+  request.msgid = 1234;
+  request.method = (string) STRING_INIT;
+  request.params = params;
+  assert_int_not_equal(0, message_serialize_request(&request, &pk));
+  msgpack_sbuffer_clear(&sbuf);
+
+  free_params(request.params);
+
+  /* no valid params */
+  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+  request.type = MESSAGE_TYPE_RESPONSE;
+  request.msgid = 1234;
+  request.method = (string) {.str = "test method",
+      .length = sizeof("test method") - 1};
+  request.params = (array) ARRAY_INIT;
+  assert_int_not_equal(0, message_serialize_request(&request, &pk));
+  msgpack_sbuffer_clear(&sbuf);
+
+  msgpack_sbuffer_destroy(&sbuf);
+}

--- a/test/unit/message-serialize-request.c
+++ b/test/unit/message-serialize-request.c
@@ -70,5 +70,8 @@ void unit_message_serialize_request(UNUSED(void **state))
 
   free_params(request.params);
 
+  /* null check */
+  assert_int_not_equal(0, message_serialize_request(NULL, NULL));
+
   msgpack_sbuffer_destroy(&sbuf);
 }

--- a/test/unit/message-serialize-response.c
+++ b/test/unit/message-serialize-response.c
@@ -55,8 +55,11 @@ void unit_message_serialize_response(UNUSED(void **state))
   response.params = params;
   assert_int_not_equal(0, message_serialize_response(&response, &pk));
   msgpack_sbuffer_clear(&sbuf);
-  
+
   free_params(response.params);
+
+  /* null check */
+  assert_int_not_equal(0, message_serialize_response(NULL, NULL));
 
   msgpack_sbuffer_destroy(&sbuf);
 }

--- a/test/unit/message-serialize-response.c
+++ b/test/unit/message-serialize-response.c
@@ -21,11 +21,11 @@
 #include "helper-unix.h"
 
 
-void unit_message_serialize_request(UNUSED(void **state))
+void unit_message_serialize_response(UNUSED(void **state))
 {
   msgpack_sbuffer sbuf;
   msgpack_packer pk;
-  struct message_request request;
+  struct message_response response;
   array params;
 
   params.size = 1;
@@ -37,22 +37,12 @@ void unit_message_serialize_request(UNUSED(void **state))
 
   /* positiv test */
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  request.msgid = 1234;
-  request.method = (string) {.str = "test method",
-      .length = sizeof("test method") - 1};
-  request.params = params;
-  assert_int_equal(0, message_serialize_request(&request, &pk));
+  response.msgid = 1234;
+  response.params = params;
+  assert_int_equal(0, message_serialize_response(&response, &pk));
   msgpack_sbuffer_clear(&sbuf);
 
-  /* no valid string */
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  request.msgid = 1234;
-  request.method = (string) STRING_INIT;
-  request.params = params;
-  assert_int_not_equal(0, message_serialize_request(&request, &pk));
-  msgpack_sbuffer_clear(&sbuf);
-
-  free_params(request.params);
+  free_params(response.params);
 
   params.size = 1;
   params.obj = CALLOC(1, struct message_object);
@@ -61,14 +51,12 @@ void unit_message_serialize_request(UNUSED(void **state))
 
   /* no valid params */
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  request.msgid = 1234;
-  request.method = (string) {.str = "test method",
-      .length = sizeof("test method") - 1};
-  request.params = params;
-  assert_int_not_equal(0, message_serialize_request(&request, &pk));
+  response.msgid = 1234;
+  response.params = params;
+  assert_int_not_equal(0, message_serialize_response(&response, &pk));
   msgpack_sbuffer_clear(&sbuf);
-
-  free_params(request.params);
+  
+  free_params(response.params);
 
   msgpack_sbuffer_destroy(&sbuf);
 }

--- a/test/wrapper-functions.c
+++ b/test/wrapper-functions.c
@@ -50,22 +50,17 @@ int __wrap_outputstream_write(UNUSED(outputstream *ostream), char *buffer, size_
 struct callinfo *__wrap_loop_wait_for_response(UNUSED(struct connection *con),
     UNUSED(struct message_request *request))
 {
-  struct message_response *response;
   struct callinfo *cinfo;
 
   cinfo = MALLOC(struct callinfo);
   assert_non_null(cinfo);
 
-  response = MALLOC(struct message_response);
-  assert_non_null(response);
-
   /* The callid and the message_params type are determined by the unit test. */
-  response->params.size = 1;
-  response->params.obj = CALLOC(response->params.size, struct message_object);
-  response->params.obj[0].type = (message_object_type)mock();
-  response->params.obj[0].data.uinteger = (uint64_t)mock();
-
-  cinfo->response = response;
+  cinfo->response.params.size = 1;
+  cinfo->response.params.obj = CALLOC(cinfo->response.params.size,
+      struct message_object);
+  cinfo->response.params.obj[0].type = (message_object_type)mock();
+  cinfo->response.params.obj[0].data.uinteger = (uint64_t)mock();
 
   return (cinfo);
 }


### PR DESCRIPTION
This PR introduces some adjustments to the message.c deserializer implementation and implements tests for message_deserialize_request and message_deserialize_response (#34). 
