### PR TITLE
Memory leak fixes (in progress)

### DIFF
--- a/src/api/register.c
+++ b/src/api/register.c
@@ -21,8 +21,8 @@
 #include "api/sb-api.h"
 
 int api_register(string name, string desc,
-    string author, string license, array functions, struct connection *con,
-    uint32_t msgid, struct api_error *api_error)
+    string author, string license, array functions, uint64_t con_id,
+    uint32_t msgid, char *pluginkey, struct api_error *api_error)
 {
   struct message_object *func;
   array params = ARRAY_INIT;
@@ -33,7 +33,7 @@ int api_register(string name, string desc,
     return (-1);
   }
 
-  if (db_plugin_add(con->cc.pluginkeystring, name, desc, author, license) == -1) {
+  if (db_plugin_add(pluginkey, name, desc, author, license) == -1) {
     error_set(api_error, API_ERROR_TYPE_VALIDATION,
         "Failed to register plugin in database.");
     return (-1);
@@ -48,7 +48,7 @@ int api_register(string name, string desc,
       continue;
     }
 
-    if (db_function_add(con->cc.pluginkeystring, &func->data.params) == -1) {
+    if (db_function_add(pluginkey, &func->data.params) == -1) {
       error_set(api_error, API_ERROR_TYPE_VALIDATION,
           "Failed to register function in database.");
       continue;
@@ -58,7 +58,7 @@ int api_register(string name, string desc,
   if (api_error->isset)
     return (-1);
 
-  if (connection_send_response(con, msgid, params, api_error) < 0) {
+  if (connection_send_response(con_id, msgid, params, api_error) < 0) {
     return (-1);
   };
 

--- a/src/api/result.c
+++ b/src/api/result.c
@@ -21,7 +21,7 @@
 #include "sb-common.h"
 
 int api_result(char *targetpluginkey, uint64_t callid,
-    struct message_object args, struct connection *con, uint32_t msgid,
+    struct message_object args, uint64_t con_id, uint32_t msgid,
     struct api_error *api_error)
 {
   struct message_object *data;
@@ -90,7 +90,7 @@ int api_result(char *targetpluginkey, uint64_t callid,
   result_response_params.obj[0].type = OBJECT_TYPE_UINT;
   result_response_params.obj[0].data.uinteger = callid;
 
-  if (connection_send_response(con, msgid, result_response_params, api_error) < 0) {
+  if (connection_send_response(con_id, msgid, result_response_params, api_error) < 0) {
     return (-1);
   };
 

--- a/src/api/run.c
+++ b/src/api/run.c
@@ -21,7 +21,7 @@
 #include "api/sb-api.h"
 
 int api_run(char *targetpluginkey, string function_name, uint64_t callid,
-    struct message_object args, struct connection *con,
+    struct message_object args, uint64_t con_id,
     uint32_t msgid, struct api_error *api_error)
 {
   struct message_object *data;
@@ -110,7 +110,7 @@ int api_run(char *targetpluginkey, string function_name, uint64_t callid,
   run_response_params.obj[0].type = OBJECT_TYPE_UINT;
   run_response_params.obj[0].data.uinteger = callid;
 
-  if (connection_send_response(con, msgid, run_response_params, api_error) < 0) {
+  if (connection_send_response(con_id, msgid, run_response_params, api_error) < 0) {
     return (-1);
   };
 

--- a/src/api/sb-api.h
+++ b/src/api/sb-api.h
@@ -34,8 +34,8 @@
  * @return 0 in case of success otherwise 1
  */
  int api_register(string name, string desc,
-     string author, string license, array functions, struct connection *con,
-     uint32_t msgid, struct api_error *api_error);
+     string author, string license, array functions, uint64_t con_id,
+     uint32_t msgid, char *pluginkey, struct api_error *api_error);
 
 /**
  * Run a plugin function
@@ -47,8 +47,8 @@
  * @return 0 in case of success otherwise -1
  */
 int api_run(char *targetpluginkey, string function_name, uint64_t callid,
-    struct message_object args, struct connection *con,
-    uint32_t msgid, struct api_error *api_error);
+    struct message_object args, uint64_t con_id, uint32_t msgid,
+    struct api_error *api_error);
 
 /**
  * Generates an API key using /dev/urandom. The length of the key
@@ -59,5 +59,5 @@ int api_run(char *targetpluginkey, string function_name, uint64_t callid,
 int api_get_key(string key);
 
 int api_result(char *targetpluginkey, uint64_t callid,
-    struct message_object args, struct connection *con, uint32_t msgid,
+    struct message_object args, uint64_t con_id, uint32_t msgid,
     struct api_error *api_error);

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -141,3 +141,4 @@ MAP_IMPL(cstr_t, ptr_t, DEFAULT_INITIALIZER) /* maps pluginkey <> connection */
 MAP_IMPL(string, dispatch_info, {.func = NULL, .async = false, .name = {.str = NULL, .length = 0}})
 MAP_IMPL(uint64_t, string, {.str = NULL, .length = 0})
 MAP_IMPL(uint64_t, ptr_t, DEFAULT_INITIALIZER) /* maps callid <> pluginkey */
+MAP_IMPL(cstr_t, uint64_t, DEFAULT_INITIALIZER)

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -137,8 +137,17 @@
     kh_clear(T##_##U##_map, map->table);                                      \
   }
 
-MAP_IMPL(cstr_t, ptr_t, DEFAULT_INITIALIZER) /* maps pluginkey <> connection */
+/* callid -> pluginkey
+ * connection id -> connection */
+MAP_IMPL(uint64_t, ptr_t, DEFAULT_INITIALIZER)
+
+/* pluginkey -> connection
+ * formatted address to listen to -> server */
+MAP_IMPL(cstr_t, ptr_t, DEFAULT_INITIALIZER)
+
+/* RPC function name -> dispatch info */
 MAP_IMPL(string, dispatch_info, {.func = NULL, .async = false, .name = {.str = NULL, .length = 0}})
-MAP_IMPL(uint64_t, string, {.str = NULL, .length = 0})
-MAP_IMPL(uint64_t, ptr_t, DEFAULT_INITIALIZER) /* maps callid <> pluginkey */
+
+/* pluginkey -> connection id */
 MAP_IMPL(cstr_t, uint64_t, DEFAULT_INITIALIZER)
+

--- a/src/rpc/connection/inputstream.c
+++ b/src/rpc/connection/inputstream.c
@@ -51,6 +51,7 @@ inputstream *inputstream_new(inputstream_cb cb, uint32_t buffer_size,
   rs->size = 0;
   rs->cb = cb;
   rs->stream = NULL;
+  rs->free_handle = false;
 
   /* initialize circular buffer */
   rs->circbuf_start = MALLOC_ARRAY(buffer_size, unsigned char);
@@ -89,7 +90,11 @@ void inputstream_free(inputstream *istream)
   sbassert(istream);
   sbassert(istream->stream);
 
-  uv_close((uv_handle_t *)istream->stream, inputstream_close_cb);
+  if (istream->free_handle)
+    uv_close((uv_handle_t *)istream->stream, inputstream_close_cb);
+
+  FREE(istream->circbuf_start);
+  FREE(istream);
 }
 
 

--- a/src/rpc/connection/loop.c
+++ b/src/rpc/connection/loop.c
@@ -47,7 +47,7 @@ static inline void loop_poll_events_until(struct connection *con,
     if (con->queue && !equeue_empty(con->queue)) {
       equeue_run_events(con->queue);
     } else {
-      uv_run(&loop, UV_RUN_NOWAIT);
+      uv_run(&loop, UV_RUN_ONCE);
       equeue_run_events(equeue_root);
     }
   }

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -247,8 +247,6 @@ struct queue_entry {
 };
 
 /* hashmap declarations */
-MAP_DECLS(uint64_t, string)
-MAP_DECLS(string, ptr_t)
 
 /* callid -> pluginkey
  * connection id -> connection */

--- a/src/rpc/sb-rpc.h
+++ b/src/rpc/sb-rpc.h
@@ -249,9 +249,19 @@ struct queue_entry {
 /* hashmap declarations */
 MAP_DECLS(uint64_t, string)
 MAP_DECLS(string, ptr_t)
-MAP_DECLS(uint64_t, ptr_t) /* maps callid <> pluginkey */
-MAP_DECLS(cstr_t, ptr_t) /* maps pluginkey <> connection */
+
+/* callid -> pluginkey
+ * connection id -> connection */
+MAP_DECLS(uint64_t, ptr_t)
+
+/* pluginkey -> connection
+ * formatted address to listen to -> server */
+MAP_DECLS(cstr_t, ptr_t)
+
+/* RPC function name -> dispatch info */
 MAP_DECLS(string, dispatch_info)
+
+/* pluginkey -> connection id */
 MAP_DECLS(cstr_t, uint64_t)
 
 /* define global root event queue */

--- a/test/functional/dispatch-handle-register.c
+++ b/test/functional/dispatch-handle-register.c
@@ -52,6 +52,8 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   info.con = CALLOC(1, struct connection);
   info.con->closed = true;
   info.con->id = 1234;
+  info.con->refcount++;
+
   strlcpy(info.con->cc.pluginkeystring, pluginkey, PLUGINKEY_STRING_SIZE+1);
   assert_non_null(info.con);
 

--- a/test/functional/dispatch-handle-register.c
+++ b/test/functional/dispatch-handle-register.c
@@ -48,13 +48,16 @@ void functional_dispatch_handle_register(UNUSED(void **state))
 
   info.api_error.isset = false;
 
-  info.con = MALLOC(struct connection);
+  info.con = CALLOC(1, struct connection);
   info.con->closed = true;
+  info.con->id = 1234;
   strlcpy(info.con->cc.pluginkeystring, pluginkey, PLUGINKEY_STRING_SIZE+1);
   assert_non_null(info.con);
 
   connect_and_create(info.con->cc.pluginkeystring);
   assert_int_equal(0, connection_init());
+
+  connection_hashmap_put(info.con->id, info.con);
 
   /* first level arrays:
    *
@@ -114,12 +117,12 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   /* a valid request has to trigger the corresponding response */
   assert_false(info.api_error.isset);
   expect_check(__wrap_crypto_write, &deserialized, validate_register_response, NULL);
-  assert_int_equal(0, handle_register(&info));
+  assert_int_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
 
   /* payload does not consist of two arrays, meta and func */
   request->params.size = 1;
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_register(&info));
+  assert_int_not_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -128,7 +131,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   /* object has wrong type */
   request->params.obj[0].type = OBJECT_TYPE_STR;
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_register(&info));
+  assert_int_not_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -137,7 +140,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   /* meta has wrong size */
   meta->size = 3;
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_register(&info));
+  assert_int_not_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -154,7 +157,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   meta->obj[0].data.string.length = len;
   assert_false(info.api_error.isset);
   expect_check(__wrap_crypto_write, &deserialized, validate_register_response, NULL);
-  assert_int_equal(0, handle_register(&info));
+  assert_int_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_false(info.api_error.isset);
   meta->obj[0].data.string = name;
   FREE(buf);
@@ -162,7 +165,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   /* no function description field should fail */
   func1->obj[1].type = OBJECT_TYPE_NIL;
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_register(&info));
+  assert_int_not_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   func1->obj[1].type = OBJECT_TYPE_STR;
@@ -178,7 +181,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   func1->obj[1].data.string.length = len;
   assert_false(info.api_error.isset);
   expect_check(__wrap_crypto_write, &deserialized, validate_register_response, NULL);
-  assert_int_equal(0, handle_register(&info));
+  assert_int_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_false(info.api_error.isset);
   func1->obj[1].data.string = func_desc;
   FREE(buf);
@@ -186,7 +189,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   /* registering w/o function, should not work */
   functions->size = 0;
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_register(&info));
+  assert_int_not_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -203,7 +206,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   args->obj[1].data.string = cstring_copy_string("foobar");
   assert_false(info.api_error.isset);
   expect_check(__wrap_crypto_write, &deserialized, validate_register_response, NULL);
-  assert_int_equal(0, handle_register(&info));
+  assert_int_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_false(info.api_error.isset);
   info.api_error.isset = false;
 
@@ -211,7 +214,7 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   functions->size = 1;
   assert_false(info.api_error.isset);
   expect_check(__wrap_crypto_write, &deserialized, validate_register_response, NULL);
-  assert_int_equal(0, handle_register(&info));
+  assert_int_equal(0, handle_register(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_false(info.api_error.isset);
   info.api_error.isset = false;
   functions->size = 2;
@@ -219,5 +222,6 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   free_params(request->params);
   connection_teardown();
   FREE(err);
+  FREE(info.con);
   db_close();
 }

--- a/test/functional/dispatch-handle-register.c
+++ b/test/functional/dispatch-handle-register.c
@@ -52,8 +52,6 @@ void functional_dispatch_handle_register(UNUSED(void **state))
   info.con = CALLOC(1, struct connection);
   info.con->closed = true;
   info.con->id = 1234;
-  info.con->refcount++;
-
   strlcpy(info.con->cc.pluginkeystring, pluginkey, PLUGINKEY_STRING_SIZE+1);
   assert_non_null(info.con);
 

--- a/test/functional/dispatch-handle-register.c
+++ b/test/functional/dispatch-handle-register.c
@@ -15,6 +15,7 @@
  */
 
 #include <msgpack.h>
+#include <bsd/string.h>
 
 #include "sb-common.h"
 #include "tweetnacl.h"

--- a/test/functional/dispatch-handle-result.c
+++ b/test/functional/dispatch-handle-result.c
@@ -38,8 +38,6 @@ static struct plugin *prepare_test(connection_request_event_info *info)
   /* establish fake connection to plugin */
   info->con = CALLOC(1, struct connection);
   info->con->closed = true;
-  info->con->refcount++;
-
   connection_hashmap_put(info->con->id, info->con);
   strlcpy(info->con->cc.pluginkeystring, plugin->key.str, plugin->key.length+1);
   assert_non_null(info->con);

--- a/test/functional/dispatch-handle-result.c
+++ b/test/functional/dispatch-handle-result.c
@@ -38,6 +38,8 @@ static struct plugin *prepare_test(connection_request_event_info *info)
   /* establish fake connection to plugin */
   info->con = CALLOC(1, struct connection);
   info->con->closed = true;
+  info->con->refcount++;
+
   connection_hashmap_put(info->con->id, info->con);
   strlcpy(info->con->cc.pluginkeystring, plugin->key.str, plugin->key.length+1);
   assert_non_null(info->con);

--- a/test/functional/dispatch-handle-result.c
+++ b/test/functional/dispatch-handle-result.c
@@ -15,6 +15,7 @@
  */
 
 #include <msgpack.h>
+#include <bsd/string.h>
 
 #include "helper-all.h"
 #include "sb-common.h"

--- a/test/functional/dispatch-handle-result.c
+++ b/test/functional/dispatch-handle-result.c
@@ -35,8 +35,9 @@ static struct plugin *prepare_test(connection_request_event_info *info)
   helper_register_plugin(plugin);
 
   /* establish fake connection to plugin */
-  info->con = MALLOC(struct connection);
+  info->con = CALLOC(1, struct connection);
   info->con->closed = true;
+  connection_hashmap_put(info->con->id, info->con);
   strlcpy(info->con->cc.pluginkeystring, plugin->key.str, plugin->key.length+1);
   assert_non_null(info->con);
 
@@ -52,7 +53,7 @@ static struct plugin *prepare_test(connection_request_event_info *info)
     ,OBJECT_TYPE_ARRAY  /* arguments */
   );
 
-  assert_int_equal(0, handle_run(info));
+  assert_int_equal(0, handle_run(info->con->id, &info->request, info->con->cc.pluginkeystring, &info->api_error));
   free_params(info->request.params);
 
   return plugin;
@@ -80,7 +81,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
     ,OBJECT_TYPE_ARRAY  /* arguments */
   );
 
-  assert_int_equal(0, handle_result(&info));
+  assert_int_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
 
   /*
    * The following asserts verify, that the handle_result method cancels
@@ -91,7 +92,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   /* size of payload too small */
   info.request.params.size = 1;
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -99,7 +100,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   /* size of payload too big */
   info.request.params.size = 3;
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -110,7 +111,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   helper_request_set_meta_size(&info.request,
     OBJECT_TYPE_ARRAY, 2);
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -122,7 +123,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   helper_request_set_meta_size(&info.request,
     OBJECT_TYPE_STR, 1);
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -133,7 +134,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   /* wrong callid type */
   helper_request_set_callid(&info.request, OBJECT_TYPE_STR);
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -143,7 +144,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   /* wrong callid */
   info.request.params.obj[0].data.params.obj[0].data.uinteger = 0;
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -154,7 +155,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
   helper_request_set_args_size(&info.request,
     OBJECT_TYPE_STR, 2);
 
-  assert_int_not_equal(0, handle_result(&info));
+  assert_int_not_equal(0, handle_result(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -165,7 +166,7 @@ void functional_dispatch_handle_result(UNUSED(void **state))
 
   free_params(info.request.params);
   helper_free_plugin(plugin);
-  FREE(info.con);
   connection_teardown();
+  FREE(info.con);
   db_close();
 }

--- a/test/functional/dispatch-handle-run.c
+++ b/test/functional/dispatch-handle-run.c
@@ -143,6 +143,7 @@ void functional_dispatch_handle_run(UNUSED(void **state))
   helper_request_set_callid(&info.request, OBJECT_TYPE_NIL);
 
   free_params(info.request.params);
+  FREE(info.con);
   helper_free_plugin(plugin);
   connection_teardown();
   db_close();

--- a/test/functional/dispatch-handle-run.c
+++ b/test/functional/dispatch-handle-run.c
@@ -15,6 +15,7 @@
  */
 
 #include <msgpack.h>
+#include <bsd/string.h>
 
 #include "sb-common.h"
 #include "rpc/msgpack/sb-msgpack-rpc.h"

--- a/test/functional/dispatch-handle-run.c
+++ b/test/functional/dispatch-handle-run.c
@@ -34,8 +34,10 @@ static struct plugin *prepare_test(connection_request_event_info *info)
   helper_register_plugin(plugin);
 
   /* establish fake connection to plugin */
-  info->con = MALLOC(struct connection);
+  info->con = CALLOC(1, struct connection);
   info->con->closed = true;
+  info->con->id = 12345;
+  connection_hashmap_put(info->con->id, info->con);
   strlcpy(info->con->cc.pluginkeystring, plugin->key.str, plugin->key.length+1);
   assert_non_null(info->con);
 
@@ -66,7 +68,9 @@ void functional_dispatch_handle_run(UNUSED(void **state))
     ,OBJECT_TYPE_ARRAY  /* arguments */
   );
 
-  assert_int_equal(0, handle_run(&info));
+  //nfo.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error
+
+  assert_int_equal(0, handle_run(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_false(info.api_error.isset);
 
   /*
@@ -79,7 +83,7 @@ void functional_dispatch_handle_run(UNUSED(void **state))
   helper_request_set_function_name(&info.request, OBJECT_TYPE_STR,
     "invalid funcion name");
 
-  assert_int_not_equal(0, handle_run(&info));
+  assert_int_not_equal(0, handle_run(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -92,7 +96,7 @@ void functional_dispatch_handle_run(UNUSED(void **state))
   helper_request_set_meta_size(&info.request, OBJECT_TYPE_STR, 2);
 
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_run(&info));
+  assert_int_not_equal(0, handle_run(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -104,7 +108,7 @@ void functional_dispatch_handle_run(UNUSED(void **state))
   helper_request_set_meta_size(&info.request, OBJECT_TYPE_ARRAY, 3);
 
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_run(&info));
+  assert_int_not_equal(0, handle_run(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
@@ -116,19 +120,21 @@ void functional_dispatch_handle_run(UNUSED(void **state))
   helper_request_set_pluginkey_type(&info.request, OBJECT_TYPE_ARRAY, plugin->key.str);
 
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_run(&info));
+  assert_int_not_equal(0, handle_run(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
   info.api_error.isset = false;
 
   /* reset to correct request */
   helper_request_set_pluginkey_type(&info.request, OBJECT_TYPE_STR, plugin->key.str);
+  array *meta = &info.request.params.obj[0].data.params;
+  free_string(meta->obj[0].data.string);
 
   /* call_id has wrong type */
   helper_request_set_callid(&info.request, OBJECT_TYPE_BIN);
 
   assert_false(info.api_error.isset);
-  assert_int_not_equal(0, handle_run(&info));
+  assert_int_not_equal(0, handle_run(info.con->id, &info.request, info.con->cc.pluginkeystring, &info.api_error));
   assert_true(info.api_error.isset);
   assert_true(info.api_error.type == API_ERROR_TYPE_VALIDATION);
 
@@ -137,7 +143,6 @@ void functional_dispatch_handle_run(UNUSED(void **state))
 
   free_params(info.request.params);
   helper_free_plugin(plugin);
-  FREE(info.con);
   connection_teardown();
   db_close();
 }

--- a/test/functional/dispatch-handle-run.c
+++ b/test/functional/dispatch-handle-run.c
@@ -38,8 +38,6 @@ static struct plugin *prepare_test(connection_request_event_info *info)
   info->con = CALLOC(1, struct connection);
   info->con->closed = true;
   info->con->id = 12345;
-  info->con->refcount++;
-
   connection_hashmap_put(info->con->id, info->con);
   strlcpy(info->con->cc.pluginkeystring, plugin->key.str, plugin->key.length+1);
   assert_non_null(info->con);

--- a/test/functional/dispatch-handle-run.c
+++ b/test/functional/dispatch-handle-run.c
@@ -38,6 +38,8 @@ static struct plugin *prepare_test(connection_request_event_info *info)
   info->con = CALLOC(1, struct connection);
   info->con->closed = true;
   info->con->id = 12345;
+  info->con->refcount++;
+
   connection_hashmap_put(info->con->id, info->con);
   strlcpy(info->con->cc.pluginkeystring, plugin->key.str, plugin->key.length+1);
   assert_non_null(info->con);

--- a/test/functional/dispatch-handle-run.c
+++ b/test/functional/dispatch-handle-run.c
@@ -145,7 +145,6 @@ void functional_dispatch_handle_run(UNUSED(void **state))
   helper_request_set_callid(&info.request, OBJECT_TYPE_NIL);
 
   free_params(info.request.params);
-  FREE(info.con);
   helper_free_plugin(plugin);
   connection_teardown();
   db_close();

--- a/test/helper-all.c
+++ b/test/helper-all.c
@@ -204,7 +204,6 @@ void helper_register_plugin(struct plugin *p)
   assert_false(info.api_error.isset);
 
   //hashmap_put(uint64_t, ptr_t)(connections, info.con->id, info.con);
-  FREE(info.con);
   free_params(register_request->params);
   //FREE(args->obj);
   //FREE(func1->obj);

--- a/test/helper-all.c
+++ b/test/helper-all.c
@@ -15,6 +15,7 @@
  */
 
 #include <hiredis/hiredis.h>
+#include <bsd/string.h>
 
 #include "sb-common.h"
 #include "rpc/db/sb-db.h"

--- a/test/helper-all.c
+++ b/test/helper-all.c
@@ -204,6 +204,7 @@ void helper_register_plugin(struct plugin *p)
   assert_false(info.api_error.isset);
 
   //hashmap_put(uint64_t, ptr_t)(connections, info.con->id, info.con);
+  FREE(info.con);
   free_params(register_request->params);
   //FREE(args->obj);
   //FREE(func1->obj);

--- a/test/unit/server-start.c
+++ b/test/unit/server-start.c
@@ -19,6 +19,7 @@
 
 #include "sb-common.h"
 #include "rpc/sb-rpc.h"
+#include "helper-all.h"
 #include "helper-unix.h"
 #include "rpc/db/sb-db.h"
 

--- a/test/unit/server-stop.c
+++ b/test/unit/server-stop.c
@@ -16,6 +16,7 @@
 
 #include "sb-common.h"
 #include "rpc/sb-rpc.h"
+#include "helper-all.h"
 #include "helper-unix.h"
 #include "rpc/db/sb-db.h"
 


### PR DESCRIPTION
This PR fixes a bunch of memory leak errors:
- restructure API and Connection module (use of crypto context is excluded from
  api module)
- introduced connection reference counter which is used for connection
  object memory management
- fix 18/21 memory leak issues in the tests
